### PR TITLE
fix TObjArray types in `besio`

### DIFF
--- a/src/pybes3/besio/root_io.py
+++ b/src/pybes3/besio/root_io.py
@@ -126,12 +126,12 @@ branchname_to_element_type = {
     "TRecEvent/m_recZddChannelCol": (kTObjArray, "TRecZddChannel"),
     # This is an TObject, not a TObjArray
     "TEvtRecObject/m_evtRecEvent": (kTObject, "TEvtRecEvent"),
-    "TEvtRecObject/m_evtRecTrackCol": (kTObjArray, "TEvtRecDTag"),
+    "TEvtRecObject/m_evtRecTrackCol": (kTObjArray, "TEvtRecTrack"),
     # This is an TObject, not a TObjArray
     "TEvtRecObject/m_evtRecPrimaryVertex": (kTObject, "TEvtRecPrimaryVertex"),
-    "TEvtRecObject/m_evtRecVeeVertexCol": (kTObjArray, "TEvtRecDTag"),
-    "TEvtRecObject/m_evtRecPi0Col": (kTObjArray, "TEvtRecDTag"),
-    "TEvtRecObject/m_evtRecEtaToGGCol": (kTObjArray, "TEvtRecDTag"),
+    "TEvtRecObject/m_evtRecVeeVertexCol": (kTObjArray, "TEvtRecVeeVertex"),
+    "TEvtRecObject/m_evtRecPi0Col": (kTObjArray, "TEvtRecPi0"),
+    "TEvtRecObject/m_evtRecEtaToGGCol": (kTObjArray, "TEvtRecEtaToGG"),
     "TEvtRecObject/m_evtRecDTagCol": (kTObjArray, "TEvtRecDTag"),
     "THltEvent/m_hltRawCol": (kTObjArray, "THltRaw"),
     # This is an TObject, not a TObjArray

--- a/tests/besio/test_besio.py
+++ b/tests/besio/test_besio.py
@@ -22,57 +22,39 @@ def test_uproot_branches():
 
 def test_mc_full():
     f_rtraw = uproot.open(data_dir / "test_full_mc_evt_1.rtraw")
-    arr = f_rtraw["Event/TMcEvent"].arrays()
+    arr = f_rtraw["Event"].arrays()
     assert len(arr) == 10
 
 
 def test_mc_only_particles():
     f_rtraw = uproot.open(data_dir / "test_only_mc_particles.rtraw")
-    arr = f_rtraw["Event/TMcEvent"].arrays()
+    arr = f_rtraw["Event"].arrays()
     assert len(arr) == 10
-
-
-def test_nav():
-    f_rtraw = uproot.open(data_dir / "test_only_mc_particles.rtraw")
-    arr = f_rtraw["Event/EventNavigator"].arrays()
-    assert len(arr) == 10
-
-
-def test_evtrec():
-    f_dst = uproot.open(data_dir / "test_full_mc_evt_1.dst")
-    arr_evtrec = f_dst["Event/TEvtRecObject"].arrays()
-    assert len(arr_evtrec) == 10
 
 
 def test_dst():
     f_dst = uproot.open(data_dir / "test_full_mc_evt_1.dst")
-    arr_dst = f_dst["Event/TDstEvent"].arrays()
+    arr_dst = f_dst["Event"].arrays()
     assert len(arr_dst) == 10
-
-
-def test_digi():
-    f_dst = uproot.open(data_dir / "test_full_mc_evt_1.rec")
-    arr_digi = f_dst["Event/TDigiEvent"].arrays()
-    assert len(arr_digi) == 10
 
 
 def test_rec():
     f_rec = uproot.open(data_dir / "test_full_mc_evt_1.rec")
-    arr_rec = f_rec["Event/TRecEvent"].arrays()
+    arr_rec = f_rec["Event"].arrays()
     assert len(arr_rec) == 10
 
 
 def test_cgem_rtraw():
     f_rtraw = uproot.open(data_dir / "test_cgem.rtraw")
-    arr = f_rtraw["Event/TMcEvent"].arrays()
+    arr = f_rtraw["Event"].arrays()
     assert len(arr) == 200
 
 
 def test_uproot_concatenate():
     arr_concat1 = uproot.concatenate(
         {
-            data_dir / "test_full_mc_evt_1.rtraw": "Event/TMcEvent",
-            data_dir / "test_full_mc_evt_2.rtraw": "Event/TMcEvent",
+            data_dir / "test_full_mc_evt_1.rtraw": "Event",
+            data_dir / "test_full_mc_evt_2.rtraw": "Event",
         }
     )
     assert len(arr_concat1) == 20


### PR DESCRIPTION
This pull request includes updates to the `root_io.py` mappings and refactors several test cases in `test_besio.py` to simplify and standardize the handling of branch names in Uproot operations. The most important changes involve correcting type mappings in the ROOT I/O configuration and modifying test cases to use a more generic branch name, improving maintainability and clarity.

### Updates to ROOT I/O mappings:
* Corrected the type mappings for several branches in `src/pybes3/besio/root_io.py` to use the appropriate class names (`TEvtRecTrack`, `TEvtRecVeeVertex`, `TEvtRecPi0`, `TEvtRecEtaToGG`) instead of the incorrect `TEvtRecDTag`. This ensures accurate deserialization of ROOT objects.

### Refactoring of test cases:
* Updated test cases in `tests/besio/test_besio.py` to replace specific branch names (e.g., `"Event/TMcEvent"`, `"Event/TRecEvent"`) with the more generic `"Event"`. This change simplifies the test logic and reduces dependency on exact branch naming.
* Removed redundant test cases (`test_nav`, `test_evtrec`, `test_digi`) that were no longer necessary due to the standardization of branch handling, streamlining the test suite.