### PR TITLE
Constraint: `numba<0.62`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,13 @@ name = "pybes3"
 authors = [{ name = "Mingrun Li", email = "mrun_lee@foxmail.com" }]
 description = "Unofficial Python module for BES3"
 requires-python = ">=3.9, <3.14"
-dependencies = ["uproot>=5.3.8", "awkward", "numba", "vector", "uproot-custom==2.0.*"]
+dependencies = [
+    "uproot>=5.3.8",
+    "awkward",
+    "numba<0.62",
+    "vector",
+    "uproot-custom==2.0.*",
+]
 readme = "README.md"
 dynamic = ["version"]
 urls = { "Homepage" = "https://github.com/mrzimu/pybes3", "Documentation" = "https://pybes3.readthedocs.io/en/stable/" }


### PR DESCRIPTION
This pull request makes a minor update to the dependencies for the `pybes3` Python module. The main change is the addition of an upper version limit for the `numba` dependency to improve compatibility.

* Dependency management:
  * Updated the `numba` dependency in `pyproject.toml` to restrict its version to below 0.62 (`numba<0.62`), since at present `0.62` conflicts to `BOSS8` environment.