### PR TITLE
chore: Adopt to uproot-custom v2.1.0 and uproot v5.6.8

### DIFF
--- a/.github/workflows/semantic-pr-titles.yml
+++ b/.github/workflows/semantic-pr-titles.yml
@@ -1,0 +1,19 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/api/pybes3.md
+++ b/docs/api/pybes3.md
@@ -1,6 +1,4 @@
 ## besio
-::: pybes3.wrap_uproot
----
 ::: pybes3.open
 ---
 ::: pybes3.concatenate

--- a/docs/user-manual/digi-identifier.md
+++ b/docs/user-manual/digi-identifier.md
@@ -47,7 +47,7 @@ tof_part = digi_id.tof_id_to_part(tof_digi["m_intId"])
 emc_theta = digi_id.emc_id_to_theta(emc_digi["m_intId"])
 ```
 
-See [Digi Identify API](../../api/pybes3.detectors/#digi-identify) for all available methods.
+See [Digi Identify API](../api/pybes3.detectors.md#digi-identifier) for all available methods.
 
 ## Digi-ID calculation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ authors = [{ name = "Mingrun Li", email = "mrun_lee@foxmail.com" }]
 description = "Unofficial Python module for BES3"
 requires-python = ">=3.9, <3.14"
 dependencies = [
-    "uproot>=5.3.8",
+    "uproot>=5.6.8",
     "awkward",
     "numba",
-    "vector",
+    "vector!=1.7.0", # TODO: remove this constraint when vector 1.7.0 is fixed
     "uproot-custom==2.1.*",
 ]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "pybind11>=2.10.0", "uproot-custom==2.0.*"]
+requires = ["scikit-build-core", "pybind11==3.0.*", "uproot-custom==2.1.*"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -30,7 +30,7 @@ dependencies = [
     "awkward",
     "numba",
     "vector",
-    "uproot-custom==2.0.*",
+    "uproot-custom==2.1.*",
 ]
 readme = "README.md"
 dynamic = ["version"]

--- a/src/pybes3/__init__.py
+++ b/src/pybes3/__init__.py
@@ -8,7 +8,7 @@ check_numba_cache()
 
 from . import besio, detectors, tracks
 from ._version import __version__, version
-from .besio import concatenate, concatenate_raw, open, open_raw, wrap_uproot
+from .besio import concatenate, concatenate_raw, open, open_raw
 from .detectors import (
     emc_barrel_h1,
     emc_barrel_h2,

--- a/src/pybes3/besio/__init__.py
+++ b/src/pybes3/besio/__init__.py
@@ -1,43 +1,55 @@
 from __future__ import annotations
 
 from typing import Any
+from warnings import warn
 
 import uproot
 
+from . import root_io
 from .raw_io import RawBinaryReader
 from .raw_io import concatenate as concatenate_raw
-from .root_io import wrap_uproot
 
 
 def open(file, **kwargs) -> Any:
     """
-    A wrapper around `uproot.open` that automatically calls `wrap_uproot` before opening the file.
-
-    Parameters:
-        file (str | Path | IO | dict[str | Path | IO, str]): The file to open.
-        **kwargs (dict): Additional arguments to pass to `uproot.open`.
+    Alias for `uproot.open`.
 
     Returns:
         The uproot file object.
+
+    Warning:
+        This function is deprecated and will be removed in future versions.
+        Use `uproot.open` instread.
     """
-    wrap_uproot()
+    # TODO: Remove this in the future.
+    warn(
+        "`pybes3.open` is deprecated and will be removed in future versions. "
+        "Use `uproot.open` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return uproot.open(file, **kwargs)
 
 
-def concatenate(files, branch: str, **kwargs) -> Any:
+def concatenate(files, expressions=None, cut=None, **kwargs) -> Any:
     """
-    A wrapper around `uproot.concatenate` that automatically calls `wrap_uproot` before concatenating the files.
-
-    Parameters:
-        files (list[str | Path | IO, str]): The files to concatenate.
-        branch (str): The branch to concatenate.
-        **kwargs (dict): Additional arguments to pass to `uproot.concatenate`.
+    Alias for `uproot.concatenate`.
 
     Returns:
         The concatenated array.
+
+    Warning:
+        This function is deprecated and will be removed in future versions.
+        Use `uproot.concatenate` instread.
     """
-    wrap_uproot()
-    return uproot.concatenate({str(f): branch for f in files}, **kwargs)
+    # TODO: Remove this in the future.
+    warn(
+        "`pybes3.concatenate` is deprecated and will be removed in future versions. "
+        "Use `uproot.concatenate` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return uproot.concatenate(files, expressions, cut, **kwargs)
 
 
 def open_raw(file: str) -> RawBinaryReader:
@@ -53,4 +65,4 @@ def open_raw(file: str) -> RawBinaryReader:
     return RawBinaryReader(file)
 
 
-__all__ = ["open", "concatenate", "open_raw", "concatenate_raw", "wrap_uproot"]
+__all__ = ["open", "concatenate", "open_raw", "concatenate_raw"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import pytest
+
+import pybes3
+
+
+@pytest.fixture(scope="session")
+def data_dir():
+    yield Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="session")
+def geom_dir():
+    yield Path(pybes3.detectors.geometry.__file__).parent

--- a/tests/detectors/conftest.py
+++ b/tests/detectors/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+import uproot
+import pybes3
+
+
+@pytest.fixture(scope="session")
+def rtraw_event(data_dir):
+    yield uproot.open(data_dir / "test_full_mc_evt_1.rtraw")["Event/TDigiEvent"].arrays()

--- a/tests/detectors/test___init__.py
+++ b/tests/detectors/test___init__.py
@@ -1,13 +1,9 @@
-from pathlib import Path
-
 import awkward as ak
 import numpy as np
+import uproot
 
 import pybes3 as p3
 import pybes3.detectors as det
-
-data_dir = Path(__file__).parent.parent / "data"
-rtraw_event = p3.open(data_dir / "test_full_mc_evt_1.rtraw")["Event/TDigiEvent"].arrays()
 
 
 def test_mdc_parse_gid():
@@ -50,7 +46,7 @@ def test_mdc_parse_gid():
     ]
 
 
-def test_parse_mdc_digi_id():
+def test_parse_mdc_digi_id(rtraw_event):
     mdc_id_ak: ak.Array = rtraw_event["m_mdcDigiCol"]["m_intId"]
     mdc_fields = [
         "gid",
@@ -109,7 +105,7 @@ def test_parse_mdc_digi_id():
     assert ak.all(ak_res2["is_stereo"] == is_stereo_ak)
 
 
-def test_parse_mdc_digi():
+def test_parse_mdc_digi(rtraw_event):
     mdc_digi_ak: ak.Record = rtraw_event["m_mdcDigiCol"]
     base_fields = [
         "gid",
@@ -174,7 +170,7 @@ def test_parse_emc_gid():
     assert list(np_res2.keys()) == ["gid", "part", "theta", "phi"]
 
 
-def test_parse_emc_digi_id():
+def test_parse_emc_digi_id(rtraw_event):
     emc_id_ak: ak.Array = rtraw_event["m_emcDigiCol"]["m_intId"]
     emc_fields = [
         "gid",
@@ -229,7 +225,7 @@ def test_parse_emc_digi_id():
     assert ak.all(ak_res2["phi"] == phi_ak)
 
 
-def test_parse_emc_digi():
+def test_parse_emc_digi(rtraw_event):
     emc_digi_ak: ak.Record = rtraw_event["m_emcDigiCol"]
     base_fields = [
         "gid",
@@ -261,8 +257,8 @@ def test_parse_emc_digi():
     assert len(ak_res2.positional_axis) == 2
 
 
-def test_parse_tof_digi_id():
-    tof_id_ak: ak.Array = p3.open(data_dir / "test_mrpc.rtraw")[
+def test_parse_tof_digi_id(data_dir):
+    tof_id_ak: ak.Array = uproot.open(data_dir / "test_mrpc.rtraw")[
         "Event/TDigiEvent/m_tofDigiCol"
     ].array()["m_intId"]
 
@@ -321,8 +317,8 @@ def test_parse_tof_digi_id():
     assert int_res2["end"] == end_np[0]
 
 
-def test_parse_muc_digi_id():
-    muc_id_ak: ak.Array = p3.open(data_dir / "test_full_mc_evt_1.rtraw")[
+def test_parse_muc_digi_id(data_dir):
+    muc_id_ak: ak.Array = uproot.open(data_dir / "test_full_mc_evt_1.rtraw")[
         "Event/TDigiEvent/m_mucDigiCol"
     ].array()["m_intId"]
 
@@ -395,8 +391,8 @@ def test_parse_muc_digi_id():
     assert np.all(np_res1["strip"] == strip_np)
 
 
-def test_parse_cgem_digi_id():
-    cgem_id_ak: ak.Array = p3.open(data_dir / "test_cgem.rtraw")[
+def test_parse_cgem_digi_id(data_dir):
+    cgem_id_ak: ak.Array = uproot.open(data_dir / "test_cgem.rtraw")[
         "Event/TDigiEvent/m_cgemDigiCol"
     ].array()["m_intId"]
 

--- a/tests/detectors/test_digi_id.py
+++ b/tests/detectors/test_digi_id.py
@@ -1,17 +1,12 @@
-from pathlib import Path
-
 import awkward as ak
 import numpy as np
+import uproot
 
-import pybes3 as p3
 from pybes3 import detectors as det
 from pybes3.detectors import digi_id
 
-data_dir = Path(__file__).parent.parent / "data"
-rtraw_event = p3.open(data_dir / "test_full_mc_evt_1.rtraw")["Event/TDigiEvent"].arrays()
 
-
-def test_mdc_digi_id():
+def test_mdc_digi_id(rtraw_event):
     mdc_id_ak: ak.Array = rtraw_event["m_mdcDigiCol"]["m_intId"]
 
     # Test awkward
@@ -60,7 +55,7 @@ def test_mdc_digi_id():
     assert digi_id.check_mdc_id(tmp_id)
 
 
-def test_emc_digi_id():
+def test_emc_digi_id(rtraw_event):
     emc_id_ak: ak.Array = rtraw_event["m_emcDigiCol"]["m_intId"]
 
     # Test awkward
@@ -109,7 +104,7 @@ def test_emc_digi_id():
     assert digi_id.check_emc_id(tmp_id)
 
 
-def test_tof_digi_id():
+def test_tof_digi_id(rtraw_event):
     tof_id_ak: ak.Array = rtraw_event["m_tofDigiCol"]["m_intId"]
 
     # Test awkward
@@ -172,7 +167,7 @@ def test_tof_digi_id():
     assert digi_id.check_tof_id(tmp_id)
 
 
-def test_muc_digi_id():
+def test_muc_digi_id(rtraw_event):
     muc_id_ak: ak.Array = rtraw_event["m_mucDigiCol"]["m_intId"]
 
     # Test awkward
@@ -243,8 +238,8 @@ def test_muc_digi_id():
     assert digi_id.check_muc_id(tmp_id)
 
 
-def test_cgem_digi_id():
-    cgem_id_ak: ak.Array = p3.open(data_dir / "test_cgem.rtraw")[
+def test_cgem_digi_id(data_dir):
+    cgem_id_ak: ak.Array = uproot.open(data_dir / "test_cgem.rtraw")[
         "Event/TDigiEvent/m_cgemDigiCol"
     ].array()["m_intId"]
 

--- a/tests/test__cache_numba.py
+++ b/tests/test__cache_numba.py
@@ -5,10 +5,8 @@ from pathlib import Path
 import pybes3 as p3
 
 
-def test_detector_geometry_mdc(capsys, monkeypatch):
+def test_detector_geometry_mdc(capsys, monkeypatch, geom_dir):
     monkeypatch.setenv("PYBES3_NUMBA_CACHE_SILENT", "1")
-
-    geom_dir = Path(p3.detectors.geometry.__file__).parent
 
     # Change mdc_geom.npz mtime
     mdc_geom_path = geom_dir / "mdc_geom.npz"
@@ -22,10 +20,8 @@ def test_detector_geometry_mdc(capsys, monkeypatch):
     assert captured.out.startswith("Removed cache files:")
 
 
-def test_detector_geometry_emc(capsys, monkeypatch):
+def test_detector_geometry_emc(capsys, monkeypatch, geom_dir):
     monkeypatch.setenv("PYBES3_NUMBA_CACHE_SILENT", "1")
-
-    geom_dir = Path(p3.detectors.geometry.__file__).parent
 
     # Change emc_geom.npz mtime
     emc_geom_path = geom_dir / "emc_geom.npz"

--- a/tests/test_besio.py
+++ b/tests/test_besio.py
@@ -7,11 +7,6 @@ import pytest
 import uproot
 
 import pybes3
-import pybes3.besio as besio
-
-besio.wrap_uproot()
-
-data_dir = Path(__file__).parent / "data"
 
 
 class CompareResult(NamedTuple):
@@ -116,7 +111,7 @@ def compare_ak(arr1: ak.Array, arr2: ak.Array, item_path: str = "") -> list[Comp
             raise e
 
 
-def test_uproot_branches():
+def test_uproot_branches(data_dir):
     f_full = uproot.open(data_dir / "test_full_mc_evt_1.rtraw")
     assert len(f_full["Event/TMcEvent"].branches) == 6
 
@@ -124,7 +119,7 @@ def test_uproot_branches():
     assert len(f_only_mc_particles["Event/TMcEvent"].branches) == 6
 
 
-def test_mc_full():
+def test_mc_full(data_dir):
     f_rtraw = uproot.open(data_dir / "test_full_mc_evt_1.rtraw")
     truth_arr = ak.from_parquet(data_dir / "test_full_mc_evt_1.rtraw.parquet")
     arr = f_rtraw["Event"].arrays()
@@ -133,7 +128,7 @@ def test_mc_full():
     assert all(r.is_same for r in comp_res)
 
 
-def test_mc_only_particles():
+def test_mc_only_particles(data_dir):
     f_rtraw = uproot.open(data_dir / "test_only_mc_particles.rtraw")
     truth_arr = ak.from_parquet(data_dir / "test_only_mc_particles.rtraw.parquet")
     arr = f_rtraw["Event"].arrays()
@@ -142,7 +137,7 @@ def test_mc_only_particles():
     assert all(r.is_same for r in comp_res)
 
 
-def test_dst():
+def test_dst(data_dir):
     f_dst = uproot.open(data_dir / "test_full_mc_evt_1.dst")
     truth_arr = ak.from_parquet(data_dir / "test_full_mc_evt_1.dst.parquet")
     arr = f_dst["Event"].arrays()
@@ -151,7 +146,7 @@ def test_dst():
     assert all(r.is_same for r in comp_res)
 
 
-def test_rec():
+def test_rec(data_dir):
     f_rec = uproot.open(data_dir / "test_full_mc_evt_1.rec")
     truth_arr = ak.from_parquet(data_dir / "test_full_mc_evt_1.rec.parquet")
     arr = f_rec["Event"].arrays()
@@ -160,7 +155,7 @@ def test_rec():
     assert all(r.is_same for r in comp_res)
 
 
-def test_cgem_rtraw():
+def test_cgem_rtraw(data_dir):
     f_rtraw = uproot.open(data_dir / "test_cgem.rtraw")
     truth_arr = ak.from_parquet(data_dir / "test_cgem.rtraw.parquet")
     arr = f_rtraw["Event"].arrays()
@@ -169,7 +164,7 @@ def test_cgem_rtraw():
     assert all(r.is_same for r in comp_res)
 
 
-def test_cgem_dst():
+def test_cgem_dst(data_dir):
     f_dst = uproot.open(data_dir / "test_cgem.dst")
     truth_arr = ak.from_parquet(data_dir / "test_cgem.dst.parquet")
     arr = f_dst["Event"].arrays()
@@ -178,7 +173,7 @@ def test_cgem_dst():
     assert all(r.is_same for r in comp_res)
 
 
-def test_cgem_rec():
+def test_cgem_rec(data_dir):
     f_dst = uproot.open(data_dir / "test_cgem.rec")
     truth_arr = ak.from_parquet(data_dir / "test_cgem.rec.parquet")
     arr = f_dst["Event"].arrays()
@@ -187,7 +182,7 @@ def test_cgem_rec():
     assert all(r.is_same for r in comp_res)
 
 
-def test_uproot_concatenate():
+def test_uproot_concatenate(data_dir):
     arr_concat1 = uproot.concatenate(
         {
             data_dir / "test_full_mc_evt_1.rtraw": "Event",
@@ -205,29 +200,7 @@ def test_uproot_concatenate():
     assert len(arr_concat2) == 20
 
 
-def test_bes_open():
-    f = besio.open(data_dir / "test_full_mc_evt_1.rtraw")
-    assert len(f["Event/TMcEvent"].branches) == 6
-
-    f = besio.open(data_dir / "test_only_mc_particles.rtraw")
-    assert len(f["Event/TMcEvent"].branches) == 6
-
-
-def test_bes_concatenate():
-    arr_concat1 = besio.concatenate(
-        [data_dir / "test_full_mc_evt_1.rtraw", data_dir / "test_full_mc_evt_2.rtraw"],
-        "Event/TMcEvent",
-    )
-    assert len(arr_concat1) == 20
-
-    arr_concat2 = besio.concatenate(
-        [data_dir / "test_full_mc_evt_1.rtraw", data_dir / "test_full_mc_evt_2.rtraw"],
-        "Event/TMcEvent/m_mcParticleCol",
-    )
-    assert len(arr_concat2) == 20
-
-
-def test_symetric_matrix_expansion():
+def test_symetric_matrix_expansion(data_dir):
     def test_symetric_matrix(arr):
         arr = ak.flatten(arr)
         n_dim = int(arr.typestr.split("*")[-2].strip())
@@ -259,7 +232,7 @@ def test_symetric_matrix_expansion():
         test_symetric_matrix(tmp_arr)
 
 
-def test_digi_expand_TRawData():
+def test_digi_expand_TRawData(data_dir):
     f_rec = uproot.open(data_dir / "test_full_mc_evt_1.rec")
     arr_digi = f_rec["Event/TDigiEvent"].arrays()
     for field in arr_digi.fields:

--- a/tests/tracks/conftest.py
+++ b/tests/tracks/conftest.py
@@ -1,0 +1,81 @@
+import awkward as ak
+import pytest
+import uproot
+
+
+@pytest.fixture(scope="session")
+def mdc_trk(data_dir):
+    yield uproot.open(data_dir / "test_full_mc_evt_1.dst")[
+        "Event/TDstEvent/m_mdcTrackCol"
+    ].array()
+
+
+@pytest.fixture(scope="session")
+def raw_helix_arr(mdc_trk):
+    yield mdc_trk["m_helix"]
+
+
+@pytest.fixture(scope="session")
+def raw_helix_err_arr(mdc_trk):
+    yield mdc_trk["m_err"]
+
+
+@pytest.fixture(scope="session")
+def flat_helix_arr(raw_helix_arr):
+    yield ak.flatten(raw_helix_arr)
+
+
+@pytest.fixture(scope="session")
+def flat_helix_err_arr(raw_helix_err_arr):
+    yield ak.flatten(raw_helix_err_arr)
+
+
+@pytest.fixture(scope="session")
+def init_pivot(request, raw_helix_arr):
+    if request.param == "ak":
+        yield ak.zip(
+            {
+                "x": ak.zeros_like(raw_helix_arr[..., 0]),
+                "y": ak.zeros_like(raw_helix_arr[..., 0]),
+                "z": ak.zeros_like(raw_helix_arr[..., 0]),
+            },
+            with_name="Vector3D",
+        )
+    else:
+        yield (0.0, 0.0, 0.0)
+
+
+@pytest.fixture(scope="session")
+def raw_pivot(request, raw_helix_arr):
+    if request.param == "ak":
+        yield (
+            ak.zip(
+                {
+                    "x": ak.zeros_like(raw_helix_arr[..., 0]),
+                    "y": ak.zeros_like(raw_helix_arr[..., 0]),
+                    "z": ak.zeros_like(raw_helix_arr[..., 0]),
+                },
+                with_name="Vector3D",
+            ),
+        )
+    elif request.param == "tuple":
+        yield (0.0, 0.0, 0.0)
+    else:
+        raise ValueError(f"Unknown raw_pivot type: {request.param}")
+
+
+@pytest.fixture(scope="session")
+def new_pivot(request, raw_helix_arr):
+    if request.param == "ak":
+        yield (
+            ak.zip(
+                {
+                    "x": ak.ones_like(raw_helix_arr[..., 0]) * 10,
+                    "y": ak.ones_like(raw_helix_arr[..., 0]) * 10,
+                    "z": ak.ones_like(raw_helix_arr[..., 0]) * 10,
+                },
+                with_name="Vector3D",
+            ),
+        )
+    else:
+        yield (10, 10, 10)

--- a/tests/tracks/test_old_helix.py
+++ b/tests/tracks/test_old_helix.py
@@ -1,21 +1,11 @@
-from pathlib import Path
-
 import awkward as ak
 import numpy as np
 import pytest
 
 import pybes3 as p3
 
-data_dir = Path(__file__).parent.parent / "data"
 
-helix_ak = p3.open(data_dir / "test_full_mc_evt_1.dst")[
-    "Event/TDstEvent/m_mdcTrackCol"
-].array()["m_helix"]
-
-helix_np = ak.flatten(helix_ak, axis=1).to_numpy()
-
-
-def test_helix():
+def test_helix(mdc_trk):
     # parse_helix
     fields = [
         "x",
@@ -32,6 +22,8 @@ def test_helix():
         "charge",
         "r_trk",
     ]
+    helix_ak = mdc_trk["m_helix"]
+    helix_np = ak.flatten(helix_ak, axis=1).to_numpy()
 
     with pytest.warns(DeprecationWarning):
         p_helix_ak1 = p3.parse_helix(helix_ak)


### PR DESCRIPTION
This pull request introduces several significant improvements and cleanup tasks across the codebase, focusing on modernizing the handling of uproot customizations, updating dependencies, and refactoring tests for better maintainability and clarity. The most important changes are grouped below.

**Core Library and API Modernization**

* Deprecated the `pybes3.open` and `pybes3.concatenate` functions, recommending direct use of `uproot.open` and `uproot.concatenate` instead, and removed the `wrap_uproot` function and related interpretation wrapping logic. Now, BES3-specific interpretation is registered directly with uproot using `uproot.register_interpretation(Bes3Interpretation)`. [[1]](diffhunk://#diff-b5496f7ab4ec1df435e4ced9ade03decef7b1fda03556d90cb05def4322df667R4-R52) [[2]](diffhunk://#diff-b5496f7ab4ec1df435e4ced9ade03decef7b1fda03556d90cb05def4322df667L56-R68) [[3]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87L376-R373)
* Updated the `pyproject.toml` to require newer versions of `pybind11`, `uproot-custom`, and `uproot`, and added a constraint for the `vector` package to avoid a problematic version. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R2) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L29-R33)

**C++ Backend Refactoring**

* Refactored C++ classes in `src/pybes3/besio/cpp/root_io.hh` to inherit from `IReader` instead of `IElementReader`, and removed redundant `final` specifiers from method overrides for better maintainability and consistency. [[1]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L15-R26) [[2]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L45-R61) [[3]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L85-R85) [[4]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L101-R107) [[5]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L127-R127) [[6]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L142-R142) [[7]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L200-R200)

**Testing Infrastructure Improvements**

* Refactored tests to use pytest fixtures for data setup, removing manual file path handling and direct calls to deprecated APIs. This includes new fixtures in `tests/conftest.py` and `tests/detectors/conftest.py`, and updating test signatures to accept these fixtures. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R15) [[2]](diffhunk://#diff-c49869b6bd864f40b1b6e3ca6cad89393b5169cc3efe98209cba318e1c901c26R1-R8) [[3]](diffhunk://#diff-626c9b18dd3e7f8ada68e8974befd7965e5cefc031f9433178b4571a59353b4cL1-L11) [[4]](diffhunk://#diff-626c9b18dd3e7f8ada68e8974befd7965e5cefc031f9433178b4571a59353b4cL53-R49) [[5]](diffhunk://#diff-626c9b18dd3e7f8ada68e8974befd7965e5cefc031f9433178b4571a59353b4cL112-R108) [[6]](diffhunk://#diff-626c9b18dd3e7f8ada68e8974befd7965e5cefc031f9433178b4571a59353b4cL177-R173) [[7]](diffhunk://#diff-626c9b18dd3e7f8ada68e8974befd7965e5cefc031f9433178b4571a59353b4cL232-R228) [[8]](diffhunk://#diff-626c9b18dd3e7f8ada68e8974befd7965e5cefc031f9433178b4571a59353b4cL264-R261) [[9]](diffhunk://#diff-626c9b18dd3e7f8ada68e8974befd7965e5cefc031f9433178b4571a59353b4cL324-R321) [[10]](diffhunk://#diff-626c9b18dd3e7f8ada68e8974befd7965e5cefc031f9433178b4571a59353b4cL398-R395) [[11]](diffhunk://#diff-2ea70d7e12b2ebec0d4c88fafc13fae545e95e312ea97b55c24d4c977c94eac3L1-R9) [[12]](diffhunk://#diff-2ea70d7e12b2ebec0d4c88fafc13fae545e95e312ea97b55c24d4c977c94eac3L63-R58)

**Documentation and Workflow Updates**

* Updated documentation links for the Digi Identifier API and removed references to deprecated functions in the API docs. [[1]](diffhunk://#diff-07f410fb1f268be20896ce9d1fefe8e7230e959e4031c079c916e79175471ac0L50-R50) [[2]](diffhunk://#diff-4990cefae783e4f0df902101e3e91661a7f8243496303453983a6ccc97861daeL2-L3)
* Added a new GitHub workflow `.github/workflows/semantic-pr-titles.yml` to enforce semantic PR title linting on pull requests.