### PR TITLE
chore: fix the nightly-build time

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -2,7 +2,7 @@ name: Nightly build
 
 on:
   schedule:
-    - cron: '12 0 * * *'  # Runs every day at 20:00 Beijing time
+    - cron: '0 12 * * *'  # Runs every day at 20:00 Beijing time
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request updates the nightly build schedule in the GitHub Actions workflow configuration. The cron expression has been changed to ensure the nightly build runs at the intended time.

* Changed the cron schedule in `.github/workflows/nightly-build.yml` to trigger the nightly build at 20:00 Beijing time, correcting the previous timing.