### PR TITLE
chore: turn nightly build to weekly build

### DIFF
--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,8 +1,8 @@
-name: Nightly build
+name: Weekly build
 
 on:
   schedule:
-    - cron: '0 12 * * *'  # Runs every day at 20:00 Beijing time
+    - cron: "0 12 * * 5"  # Runs every Friday at 12:00 UTC (20:00 Beijing Time)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request updates the build workflow schedule to run less frequently and renames the workflow for clarity.

Workflow configuration updates:

* Renamed the workflow file from `.github/workflows/nightly-build.yml` to `.github/workflows/weekly-build.yml` and changed the workflow name from "Nightly build" to "Weekly build" to better reflect the new schedule.
* Modified the cron schedule to run the workflow every Friday at 12:00 UTC (20:00 Beijing Time) instead of every day.