### PR TITLE
chore: Fix readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,14 @@ build:
   tools:
     python: "3.12"
   jobs:
-    pre_install:
-      - pip install uv
-      - uv sync --group docs
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+         - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,8 @@ build:
     python: "3.12"
   jobs:
     pre_install:
-      - pip install .[all]
+      - pip install uv
+      - uv sync --group docs
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
This pull request updates the Read the Docs build configuration to use the `uv` Python package manager via `asdf` for environment setup and dependency installation, replacing the previous `pip`-based workflow. This change modernizes the build process to improve reproducibility and efficiency.

**Build system modernization:**

* Updated `.readthedocs.yaml` to add and install the `uv` plugin using `asdf`, set up the environment with `uv venv`, and synchronize dependencies with `uv sync`, replacing the previous `pip install .[all]` step.