### PR TITLE
chore: Use github-cli to auto-merge PR

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Merge Pull Request
         if: steps.cpr.outputs.pull-request-number != ''
         run: |
-          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --admin --delete-branch
+          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --auto --delete-branch

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -42,6 +42,8 @@ jobs:
           branch: auto-update/pre-commit-uv
 
       - name: Merge Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
         if: steps.cpr.outputs.pull-request-number != ''
         run: |
           gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --auto --delete-branch

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -41,8 +41,6 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           branch: auto-update/pre-commit-uv
 
-      - name: Enable Pull Request Automerge
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
+      - name: Merge Pull Request
+        run: |
+          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --admin --delete-branch

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -42,5 +42,6 @@ jobs:
           branch: auto-update/pre-commit-uv
 
       - name: Merge Pull Request
+        if: steps.cpr.outputs.pull-request-number != ''
         run: |
           gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --admin --delete-branch


### PR DESCRIPTION
This pull request updates the workflow for automatically merging pull requests in `.github/workflows/auto-update.yml`. The main change is replacing the previous action for enabling automerge with a direct GitHub CLI command for merging pull requests.

**Workflow automation update:**

* Replaced the `peter-evans/enable-pull-request-automerge` action with a `gh pr merge` command, allowing squash merging, admin privileges, and branch deletion in a single step.