### PR TITLE
chore: Fix ci pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: uv pip install pre-commit
 
       - name: Run pre-commit
         run: pre-commit run --all-files


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration for pre-commit checks. The installation step for the `pre-commit` tool now uses `uv pip` instead of the standard `pip` command for improved performance and compatibility.