### PR TITLE
docs: Correct typo in optional parameter comment for helix_obj

### DIFF
--- a/docs/user-manual/helix.md
+++ b/docs/user-manual/helix.md
@@ -37,7 +37,7 @@ import pybes3 as p3
 
 helix = p3.helix_obj(
     params=(dr, phi0, kappa, dz, tanl), # helix parameters
-    error=error,                        # error matrix (optional
+    error=error,                        # error matrix (optional)
     pivot=(x0, y0, z0),                 # initial pivot point (optional)
 )
 ```


### PR DESCRIPTION
This pull request makes a minor formatting correction in the `docs/user-manual/helix.md` file, fixing a comment typo in the example code. No functional or structural changes were made.