### PR TITLE
fix: Typename handling and mappings in bes3_branch2types

### DIFF
--- a/src/pybes3/besio/root_io.py
+++ b/src/pybes3/besio/root_io.py
@@ -63,10 +63,10 @@ bes3_branch2types = {
     "/Event:TEvtRecObject/m_evtRecEtaToGGCol": "TEvtRecEtaToGG",
     "/Event:TEvtRecObject/m_evtRecDTagCol": "TEvtRecDTag",
     "/Event:THltEvent/m_hltRawCol": "THltRaw",
-    "/Event:EventNavigator/m_mcMdcMcHits": "map<int,int>",
-    "/Event:EventNavigator/m_mcMdcTracks": "map<int,int>",
-    "/Event:EventNavigator/m_mcEmcMcHits": "map<int,int>",
-    "/Event:EventNavigator/m_mcEmcRecShowers": "map<int,int>",
+    "/Event:EventNavigator/m_mcMdcMcHits": None,
+    "/Event:EventNavigator/m_mcMdcTracks": None,
+    "/Event:EventNavigator/m_mcEmcMcHits": None,
+    "/Event:EventNavigator/m_mcEmcRecShowers": None,
 }
 
 
@@ -379,6 +379,10 @@ class Bes3Interpretation(AsCustom):
     def __init__(self, branch, context, simplify):
         super().__init__(branch, context, simplify)
         self._typename = bes3_branch2types[regularize_object_path(branch.object_path)]
+        self.is_bes3 = self._typename is not None
+
+        if self.is_bes3:
+            self._typename = f"TObjArray<{self._typename}>"
 
     def final_array(
         self,
@@ -404,18 +408,13 @@ class Bes3Interpretation(AsCustom):
         full_branch_path = regularize_object_path(branch.object_path)
         return preprocess_subbranch(full_branch_path, arr)
 
-    @property
-    def typename(self) -> str:
-        """
-        The typename of the interpretation.
-        """
-        return self._typename
-
     def __repr__(self) -> str:
         """
         The string representation of the interpretation.
         """
-        return f"AsBes3(TObjArray[{self.typename}])"
+        if self.is_bes3:
+            return f"AsBes3({self._typename})"
+        return super().__repr__()
 
 
 uproot.register_interpretation(Bes3Interpretation)


### PR DESCRIPTION
This pull request updates the `Bes3Interpretation` class and related type handling in `root_io.py` to better distinguish between BES3 and non-BES3 data branches, and clarifies type information for certain event navigator branches. The main changes improve type assignment and string representation for custom interpretations, and handle special cases where a type is not defined.

**Type handling improvements:**

* Updated the `bes3_branch2types` mapping so that certain `/Event:EventNavigator` branches now have `None` as their type instead of `"map<int,int>"`, indicating that these do not map to a known BES3 type.
* In the `Bes3Interpretation` class, added an `is_bes3` attribute to indicate whether a branch has a recognized BES3 type, and updated `_typename` accordingly to use the `TObjArray<...>` wrapper only for BES3 types.

**Code clarity and representation:**

* Modified the `__repr__` method of `Bes3Interpretation` to provide a clearer string representation depending on whether the branch is a BES3 type or not. For BES3 types, it shows `AsBes3(TObjArray<...>)`; otherwise, it falls back to the base class representation.
* Removed the now-unnecessary `typename` property from `Bes3Interpretation`, simplifying the class.