### PR TITLE
docs: Update API documentation for GID parsing methods

### DIFF
--- a/docs/api/pybes3.md
+++ b/docs/api/pybes3.md
@@ -87,21 +87,47 @@
 ---
 ::: pybes3.mdc_layer_to_superlayer
 ---
+::: pybes3.parse_emc_gid
+---
+::: pybes3.parse_mdc_gid
+---
+::: pybes3.cgem_gid_to_is_vstrip
+---
+::: pybes3.cgem_gid_to_is_xstrip
+---
+::: pybes3.cgem_gid_to_layer
+---
+::: pybes3.cgem_gid_to_sheet
+---
+::: pybes3.cgem_gid_to_strip
+---
+::: pybes3.cgem_gid_to_strip_type
+---
+::: pybes3.get_cgem_gid
+---
+::: pybes3.parse_cgem_gid
+---
+::: pybes3.get_tof_gid
+---
+::: pybes3.parse_tof_gid
+---
+::: pybes3.tof_gid_to_layer_or_module
+---
+::: pybes3.tof_gid_to_part
+---
+::: pybes3.tof_gid_to_phi_or_strip
+---
 
 ## digi_id
-::: pybes3.parse_cgem_digi_id
+::: pybes3.parse_mdc_digi
 ---
 ::: pybes3.parse_emc_digi
 ---
+::: pybes3.parse_cgem_digi_id
+---
 ::: pybes3.parse_emc_digi_id
 ---
-::: pybes3.parse_emc_gid
----
-::: pybes3.parse_mdc_digi
----
 ::: pybes3.parse_mdc_digi_id
----
-::: pybes3.parse_mdc_gid
 ---
 ::: pybes3.parse_muc_digi_id
 ---


### PR DESCRIPTION
This pull request updates the `docs/api/pybes3.md` documentation to reorganize and expand the list of documented functions, especially for geometry ID parsing and conversion utilities. The changes improve the clarity and completeness of the API documentation, making it easier for users to find and understand the available functions.

**Documentation improvements and reorganization:**

* Added documentation entries for several new geometry ID parsing and conversion functions, such as `parse_emc_gid`, `parse_mdc_gid`, and various `cgem_gid_to_*` and `tof_gid_to_*` utilities, providing a more comprehensive overview of the API.
* Reorganized the order of `digi_id`-related functions to group similar functions together and improve logical flow, including moving and swapping the order of `parse_mdc_digi`, `parse_emc_digi_id`, and `parse_cgem_digi_id`.
* Removed duplicate or misplaced documentation entries for functions that were previously listed in the wrong sections, such as `parse_emc_gid` and `parse_mdc_gid`.