### PR TITLE
fix: Update data types for various constants and variables to avoid unexpected overflow

### DIFF
--- a/src/pybes3/detectors/cgem.py
+++ b/src/pybes3/detectors/cgem.py
@@ -23,10 +23,10 @@ N_VSTRIPS.setflags(write=False)
 
 
 def _init():
-    _layer = np.empty(N_STRIPS, dtype=np.uint8)
-    _sheet = np.empty(N_STRIPS, dtype=np.uint8)
-    _strip_type = np.empty(N_STRIPS, dtype=np.uint8)
-    _strip = np.empty(N_STRIPS, dtype=np.uint16)
+    _layer = np.empty(N_STRIPS, dtype=np.int64)
+    _sheet = np.empty(N_STRIPS, dtype=np.int64)
+    _strip_type = np.empty(N_STRIPS, dtype=np.int64)
+    _strip = np.empty(N_STRIPS, dtype=np.int64)
 
     gid = 0
     for layer in range(3):

--- a/src/pybes3/detectors/emc.py
+++ b/src/pybes3/detectors/emc.py
@@ -167,7 +167,7 @@ def get_emc_gid(part: IntLike, theta: IntLike, phi: IntLike) -> IntLike:
         if theta == 0 or theta == 1:
             return res + (1 - theta) * ENDCAP_PHI_01 + phi
 
-    return -1
+    raise ValueError(f"Unsupported part: {part}")
 
 
 @nb.vectorize(cache=True)

--- a/src/pybes3/detectors/emc.py
+++ b/src/pybes3/detectors/emc.py
@@ -29,9 +29,9 @@ BARREL_L = 28.0
 with np.load(EMC_GEOM) as f:
     _emc_geom = dict(f)
 
-_part = _emc_geom["part"]
-_theta = _emc_geom["theta"]
-_phi = _emc_geom["phi"]
+_part = _emc_geom["part"].astype(np.int64)
+_theta = _emc_geom["theta"].astype(np.int64)
+_phi = _emc_geom["phi"].astype(np.int64)
 _points_x = _emc_geom["points_x"]
 _points_y = _emc_geom["points_y"]
 _points_z = _emc_geom["points_z"]
@@ -140,34 +140,34 @@ def get_emc_gid(part: IntLike, theta: IntLike, phi: IntLike) -> IntLike:
     if part == 0:
         res = 0
         if theta == 0 or theta == 1:
-            return np.uint16(theta * ENDCAP_PHI_01 + phi)
+            return theta * ENDCAP_PHI_01 + phi
 
         res += 2 * ENDCAP_PHI_01
         if theta == 2 or theta == 3:
-            return np.uint16(res + (theta - 2) * ENDCAP_PHI_23 + phi)
+            return res + (theta - 2) * ENDCAP_PHI_23 + phi
 
         res += 2 * ENDCAP_PHI_23
         if theta == 4 or theta == 5:
-            return np.uint16(res + (theta - 4) * ENDCAP_PHI_45 + phi)
+            return res + (theta - 4) * ENDCAP_PHI_45 + phi
 
     if part == 1:
-        return np.uint16(ENDCAP_CRYSTALS + theta * BARREL_PHI + phi)
+        return ENDCAP_CRYSTALS + theta * BARREL_PHI + phi
 
     if part == 2:
         res = ENDCAP_CRYSTALS + BARREL_CRYSTALS
 
         if theta == 4 or theta == 5:
-            return np.uint16(res + (5 - theta) * ENDCAP_PHI_45 + phi)
+            return res + (5 - theta) * ENDCAP_PHI_45 + phi
 
         res += 2 * ENDCAP_PHI_45
         if theta == 2 or theta == 3:
-            return np.uint16(res + (3 - theta) * ENDCAP_PHI_23 + phi)
+            return res + (3 - theta) * ENDCAP_PHI_23 + phi
 
         res += 2 * ENDCAP_PHI_23
         if theta == 0 or theta == 1:
-            return np.uint16(res + (1 - theta) * ENDCAP_PHI_01 + phi)
+            return res + (1 - theta) * ENDCAP_PHI_01 + phi
 
-    return np.uint16(65535)
+    return -1
 
 
 @nb.vectorize(cache=True)

--- a/src/pybes3/detectors/mdc.py
+++ b/src/pybes3/detectors/mdc.py
@@ -14,19 +14,19 @@ N_WIRES = 6796
 with np.load(MDC_GEOM) as f:
     _mdc_geom_table = dict(f)
 
-_superlayer = _mdc_geom_table["superlayer"]
-_layer = _mdc_geom_table["layer"]
-_wire = _mdc_geom_table["wire"]
+_superlayer = _mdc_geom_table["superlayer"].astype(np.int64)
+_layer = _mdc_geom_table["layer"].astype(np.int64)
+_wire = _mdc_geom_table["wire"].astype(np.int64)
+_stereo = _mdc_geom_table["stereo"].astype(np.int64)
+_is_stereo = _mdc_geom_table["is_stereo"]
 _east_x = _mdc_geom_table["east_x"]
 _east_y = _mdc_geom_table["east_y"]
 _east_z = _mdc_geom_table["east_z"]
 _west_x = _mdc_geom_table["west_x"]
 _west_y = _mdc_geom_table["west_y"]
 _west_z = _mdc_geom_table["west_z"]
-_stereo = _mdc_geom_table["stereo"]
-_is_stereo = _mdc_geom_table["is_stereo"]
 
-_layer_start_gid = np.zeros(44, dtype=np.uint16)
+_layer_start_gid = np.zeros(44, dtype=np.int64)
 _layer_start_gid[1:] = np.cumsum(np.bincount(_layer, minlength=43))
 
 _dx_dz = (_east_x - _west_x) / (_east_z - _west_z)
@@ -34,7 +34,7 @@ _dy_dz = (_east_y - _west_y) / (_east_z - _west_z)
 
 
 _first_wire_idx = np.searchsorted(_layer, np.arange(43))
-_is_layer_stereo = _is_stereo[_first_wire_idx].astype(bool)
+_is_layer_stereo = _is_stereo[_first_wire_idx].copy()
 
 _superlayer_splits = np.array([0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 43])
 

--- a/src/pybes3/detectors/tof.py
+++ b/src/pybes3/detectors/tof.py
@@ -18,9 +18,9 @@ N_PHI_OR_STRIP.setflags(write=False)
 
 
 def _init():
-    _part = np.empty(N_STRIPS, dtype=np.uint8)
-    _layer_or_module = np.empty(N_STRIPS, dtype=np.uint8)
-    _phi_or_strip = np.empty(N_STRIPS, dtype=np.uint8)
+    _part = np.empty(N_STRIPS, dtype=np.int64)
+    _layer_or_module = np.empty(N_STRIPS, dtype=np.int64)
+    _phi_or_strip = np.empty(N_STRIPS, dtype=np.int64)
 
     gid = 0
     for part in range(5):

--- a/src/pybes3/digi_id.py
+++ b/src/pybes3/digi_id.py
@@ -17,71 +17,71 @@ warnings.warn(
     stacklevel=2,
 )
 
-DIGI_MDC_FLAG = np.uint32(0x10)
-DIGI_TOF_FLAG = np.uint32(0x20)
-DIGI_EMC_FLAG = np.uint32(0x30)
-DIGI_MUC_FLAG = np.uint32(0x40)
-DIGI_HLT_FLAG = np.uint32(0x50)
-DIGI_CGEM_FLAG = np.uint32(0x60)
-DIGI_MRPC_FLAG = np.uint32(0x70)
-DIGI_FLAG_OFFSET = np.uint32(24)
-DIGI_FLAG_MASK = np.uint32(0xFF000000)
+DIGI_MDC_FLAG = 0x10
+DIGI_TOF_FLAG = 0x20
+DIGI_EMC_FLAG = 0x30
+DIGI_MUC_FLAG = 0x40
+DIGI_HLT_FLAG = 0x50
+DIGI_CGEM_FLAG = 0x60
+DIGI_MRPC_FLAG = 0x70
+DIGI_FLAG_OFFSET = 24
+DIGI_FLAG_MASK = 0xFF000000
 
 # MDC
-DIGI_MDC_WIRETYPE_OFFSET = np.uint32(15)
-DIGI_MDC_WIRETYPE_MASK = np.uint32(0x00008000)
-DIGI_MDC_LAYER_OFFSET = np.uint32(9)
-DIGI_MDC_LAYER_MASK = np.uint32(0x00007E00)
-DIGI_MDC_WIRE_OFFSET = np.uint32(0)
-DIGI_MDC_WIRE_MASK = np.uint32(0x000001FF)
-DIGI_MDC_STEREO_WIRE = np.uint32(1)
+DIGI_MDC_WIRETYPE_OFFSET = 15
+DIGI_MDC_WIRETYPE_MASK = 0x00008000
+DIGI_MDC_LAYER_OFFSET = 9
+DIGI_MDC_LAYER_MASK = 0x00007E00
+DIGI_MDC_WIRE_OFFSET = 0
+DIGI_MDC_WIRE_MASK = 0x000001FF
+DIGI_MDC_STEREO_WIRE = 1
 
 # TOF
-DIGI_TOF_PART_OFFSET = np.uint32(14)
-DIGI_TOF_PART_MASK = np.uint32(0x0000C000)
-DIGI_TOF_END_OFFSET = np.uint32(0)
-DIGI_TOF_END_MASK = np.uint32(0x00000001)
+DIGI_TOF_PART_OFFSET = 14
+DIGI_TOF_PART_MASK = 0x0000C000
+DIGI_TOF_END_OFFSET = 0
+DIGI_TOF_END_MASK = 0x00000001
 
-DIGI_TOF_SCINT_LAYER_OFFSET = np.uint32(8)
-DIGI_TOF_SCINT_LAYER_MASK = np.uint32(0x00000100)
-DIGI_TOF_SCINT_PHI_OFFSET = np.uint32(1)
-DIGI_TOF_SCINT_PHI_MASK = np.uint32(0x000000FE)
+DIGI_TOF_SCINT_LAYER_OFFSET = 8
+DIGI_TOF_SCINT_LAYER_MASK = 0x00000100
+DIGI_TOF_SCINT_PHI_OFFSET = 1
+DIGI_TOF_SCINT_PHI_MASK = 0x000000FE
 
-DIGI_TOF_MRPC_ENDCAP_OFFSET = np.uint32(11)
-DIGI_TOF_MRPC_ENDCAP_MASK = np.uint32(0x00000800)
-DIGI_TOF_MRPC_MODULE_OFFSET = np.uint32(5)
-DIGI_TOF_MRPC_MODULE_MASK = np.uint32(0x000007E0)
-DIGI_TOF_MRPC_STRIP_OFFSET = np.uint32(1)
-DIGI_TOF_MRPC_STRIP_MASK = np.uint32(0x0000001E)
+DIGI_TOF_MRPC_ENDCAP_OFFSET = 11
+DIGI_TOF_MRPC_ENDCAP_MASK = 0x00000800
+DIGI_TOF_MRPC_MODULE_OFFSET = 5
+DIGI_TOF_MRPC_MODULE_MASK = 0x000007E0
+DIGI_TOF_MRPC_STRIP_OFFSET = 1
+DIGI_TOF_MRPC_STRIP_MASK = 0x0000001E
 
 # EMC
-DIGI_EMC_MODULE_OFFSET = np.uint32(16)
-DIGI_EMC_MODULE_MASK = np.uint32(0x000F0000)
-DIGI_EMC_THETA_OFFSET = np.uint32(8)
-DIGI_EMC_THETA_MASK = np.uint32(0x00003F00)
-DIGI_EMC_PHI_OFFSET = np.uint32(0)
-DIGI_EMC_PHI_MASK = np.uint32(0x000000FF)
+DIGI_EMC_MODULE_OFFSET = 16
+DIGI_EMC_MODULE_MASK = 0x000F0000
+DIGI_EMC_THETA_OFFSET = 8
+DIGI_EMC_THETA_MASK = 0x00003F00
+DIGI_EMC_PHI_OFFSET = 0
+DIGI_EMC_PHI_MASK = 0x000000FF
 
 # MUC
-DIGI_MUC_PART_OFFSET = np.uint32(16)
-DIGI_MUC_PART_MASK = np.uint32(0x000F0000)
-DIGI_MUC_SEGMENT_OFFSET = np.uint32(12)
-DIGI_MUC_SEGMENT_MASK = np.uint32(0x0000F000)
-DIGI_MUC_LAYER_OFFSET = np.uint32(8)
-DIGI_MUC_LAYER_MASK = np.uint32(0x00000F00)
-DIGI_MUC_CHANNEL_OFFSET = np.uint32(0)
-DIGI_MUC_CHANNEL_MASK = np.uint32(0x000000FF)
+DIGI_MUC_PART_OFFSET = 16
+DIGI_MUC_PART_MASK = 0x000F0000
+DIGI_MUC_SEGMENT_OFFSET = 12
+DIGI_MUC_SEGMENT_MASK = 0x0000F000
+DIGI_MUC_LAYER_OFFSET = 8
+DIGI_MUC_LAYER_MASK = 0x00000F00
+DIGI_MUC_CHANNEL_OFFSET = 0
+DIGI_MUC_CHANNEL_MASK = 0x000000FF
 
 # CGEM
-DIGI_CGEM_STRIP_OFFSET = np.uint32(7)
-DIGI_CGEM_STRIP_MASK = np.uint32(0x0007FF80)
-DIGI_CGEM_STRIPTYPE_OFFSET = np.uint32(6)
-DIGI_CGEM_STRIPTYPE_MASK = np.uint32(0x00000040)
-DIGI_CGEM_SHEET_OFFSET = np.uint32(3)
-DIGI_CGEM_SHEET_MASK = np.uint32(0x00000038)
-DIGI_CGEM_LAYER_OFFSET = np.uint32(0)
-DIGI_CGEM_LAYER_MASK = np.uint32(0x00000007)
-DIGI_CGEM_XSTRIP = np.uint32(0)
+DIGI_CGEM_STRIP_OFFSET = 7
+DIGI_CGEM_STRIP_MASK = 0x0007FF80
+DIGI_CGEM_STRIPTYPE_OFFSET = 6
+DIGI_CGEM_STRIPTYPE_MASK = 0x00000040
+DIGI_CGEM_SHEET_OFFSET = 3
+DIGI_CGEM_SHEET_MASK = 0x00000038
+DIGI_CGEM_LAYER_OFFSET = 0
+DIGI_CGEM_LAYER_MASK = 0x00000007
+DIGI_CGEM_XSTRIP = 0
 
 
 ###############################################################################
@@ -112,7 +112,7 @@ def mdc_id_to_wire(mdc_digi_id: IntLike) -> IntLike:
     Returns:
         The wire number.
     """
-    return np.uint16((mdc_digi_id & DIGI_MDC_WIRE_MASK) >> DIGI_MDC_WIRE_OFFSET)
+    return (mdc_digi_id & DIGI_MDC_WIRE_MASK) >> DIGI_MDC_WIRE_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -126,7 +126,7 @@ def mdc_id_to_layer(mdc_digi_id: IntLike) -> IntLike:
     Returns:
         The layer number.
     """
-    return np.uint8((mdc_digi_id & DIGI_MDC_LAYER_MASK) >> DIGI_MDC_LAYER_OFFSET)
+    return (mdc_digi_id & DIGI_MDC_LAYER_MASK) >> DIGI_MDC_LAYER_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -310,7 +310,7 @@ def tof_id_to_part(tof_digi_id: IntLike) -> IntLike:
     part = (tof_digi_id & DIGI_TOF_PART_MASK) >> DIGI_TOF_PART_OFFSET
     if part == 3:  # += MRPC endcap number
         part += (tof_digi_id & DIGI_TOF_MRPC_ENDCAP_MASK) >> DIGI_TOF_MRPC_ENDCAP_OFFSET
-    return np.uint8(part)
+    return part
 
 
 @nb.vectorize(cache=True)
@@ -324,7 +324,7 @@ def tof_id_to_end(tof_digi_id: IntLike) -> IntLike:
     Returns:
         The readout end number.
     """
-    return np.uint8((tof_digi_id & DIGI_TOF_END_MASK) >> DIGI_TOF_END_OFFSET)
+    return (tof_digi_id & DIGI_TOF_END_MASK) >> DIGI_TOF_END_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -346,7 +346,7 @@ def _tof_id_to_layer_or_module_1(tof_digi_id: IntLike) -> IntLike:
         res = (tof_digi_id & DIGI_TOF_SCINT_LAYER_MASK) >> DIGI_TOF_SCINT_LAYER_OFFSET
     else:
         res = (tof_digi_id & DIGI_TOF_MRPC_MODULE_MASK) >> DIGI_TOF_MRPC_MODULE_OFFSET
-    return np.uint8(res)
+    return res
 
 
 @nb.vectorize(cache=True)
@@ -367,7 +367,7 @@ def _tof_id_to_layer_or_module_2(tof_digi_id: IntLike, part: IntLike) -> IntLike
         res = (tof_digi_id & DIGI_TOF_SCINT_LAYER_MASK) >> DIGI_TOF_SCINT_LAYER_OFFSET
     else:
         res = (tof_digi_id & DIGI_TOF_MRPC_MODULE_MASK) >> DIGI_TOF_MRPC_MODULE_OFFSET
-    return np.uint8(res)
+    return res
 
 
 def tof_id_to_layer_or_module(
@@ -411,7 +411,7 @@ def _tof_id_to_phi_or_strip_1(tof_digi_id: IntLike) -> IntLike:
         res = (tof_digi_id & DIGI_TOF_SCINT_PHI_MASK) >> DIGI_TOF_SCINT_PHI_OFFSET
     else:
         res = (tof_digi_id & DIGI_TOF_MRPC_STRIP_MASK) >> DIGI_TOF_MRPC_STRIP_OFFSET
-    return np.uint8(res)
+    return res
 
 
 @nb.vectorize(cache=True)
@@ -432,7 +432,7 @@ def _tof_id_to_phi_or_strip_2(tof_digi_id: IntLike, part: IntLike) -> IntLike:
         res = (tof_digi_id & DIGI_TOF_SCINT_PHI_MASK) >> DIGI_TOF_SCINT_PHI_OFFSET
     else:
         res = (tof_digi_id & DIGI_TOF_MRPC_STRIP_MASK) >> DIGI_TOF_MRPC_STRIP_OFFSET
-    return np.uint8(res)
+    return res
 
 
 def tof_id_to_phi_or_strip(
@@ -574,7 +574,7 @@ def emc_id_to_module(emc_digi_id: IntLike) -> IntLike:
     Returns:
         The module number.
     """
-    return np.uint8((emc_digi_id & DIGI_EMC_MODULE_MASK) >> DIGI_EMC_MODULE_OFFSET)
+    return (emc_digi_id & DIGI_EMC_MODULE_MASK) >> DIGI_EMC_MODULE_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -588,7 +588,7 @@ def emc_id_to_theta(emc_digi_id: IntLike) -> IntLike:
     Returns:
         The theta number.
     """
-    return np.uint8((emc_digi_id & DIGI_EMC_THETA_MASK) >> DIGI_EMC_THETA_OFFSET)
+    return (emc_digi_id & DIGI_EMC_THETA_MASK) >> DIGI_EMC_THETA_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -602,7 +602,7 @@ def emc_id_to_phi(emc_digi_id: IntLike) -> IntLike:
     Returns:
         The phi number.
     """
-    return np.uint8((emc_digi_id & DIGI_EMC_PHI_MASK) >> DIGI_EMC_PHI_OFFSET)
+    return (emc_digi_id & DIGI_EMC_PHI_MASK) >> DIGI_EMC_PHI_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -761,7 +761,7 @@ def muc_id_to_part(muc_digi_id: IntLike) -> IntLike:
     Returns:
         The part number.
     """
-    return np.uint8((muc_digi_id & DIGI_MUC_PART_MASK) >> DIGI_MUC_PART_OFFSET)
+    return (muc_digi_id & DIGI_MUC_PART_MASK) >> DIGI_MUC_PART_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -775,7 +775,7 @@ def muc_id_to_segment(muc_digi_id: IntLike) -> IntLike:
     Returns:
         The segment number.
     """
-    return np.uint8((muc_digi_id & DIGI_MUC_SEGMENT_MASK) >> DIGI_MUC_SEGMENT_OFFSET)
+    return (muc_digi_id & DIGI_MUC_SEGMENT_MASK) >> DIGI_MUC_SEGMENT_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -789,7 +789,7 @@ def muc_id_to_layer(muc_digi_id: IntLike) -> IntLike:
     Returns:
         The layer number.
     """
-    return np.uint8((muc_digi_id & DIGI_MUC_LAYER_MASK) >> DIGI_MUC_LAYER_OFFSET)
+    return (muc_digi_id & DIGI_MUC_LAYER_MASK) >> DIGI_MUC_LAYER_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -803,7 +803,7 @@ def muc_id_to_channel(muc_digi_id: IntLike) -> IntLike:
     Returns:
         The channel number.
     """
-    return np.uint8((muc_digi_id & DIGI_MUC_CHANNEL_MASK) >> DIGI_MUC_CHANNEL_OFFSET)
+    return (muc_digi_id & DIGI_MUC_CHANNEL_MASK) >> DIGI_MUC_CHANNEL_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -941,7 +941,7 @@ def cgem_id_to_layer(cgem_digi_id: IntLike) -> IntLike:
     Returns:
         The layer number.
     """
-    return np.uint8((cgem_digi_id & DIGI_CGEM_LAYER_MASK) >> DIGI_CGEM_LAYER_OFFSET)
+    return (cgem_digi_id & DIGI_CGEM_LAYER_MASK) >> DIGI_CGEM_LAYER_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -955,7 +955,7 @@ def cgem_id_to_sheet(cgem_digi_id: IntLike) -> IntLike:
     Returns:
         The sheet number.
     """
-    return np.uint8((cgem_digi_id & DIGI_CGEM_SHEET_MASK) >> DIGI_CGEM_SHEET_OFFSET)
+    return (cgem_digi_id & DIGI_CGEM_SHEET_MASK) >> DIGI_CGEM_SHEET_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -969,7 +969,7 @@ def cgem_id_to_strip_type(cgem_digi_id: IntLike) -> IntLike:
     Returns:
         The strip type. 0 for X-strip, 1 for V-strip.
     """
-    return np.uint8((cgem_digi_id & DIGI_CGEM_STRIPTYPE_MASK) >> DIGI_CGEM_STRIPTYPE_OFFSET)
+    return (cgem_digi_id & DIGI_CGEM_STRIPTYPE_MASK) >> DIGI_CGEM_STRIPTYPE_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -983,7 +983,7 @@ def cgem_id_to_strip(cgem_digi_id: IntLike) -> IntLike:
     Returns:
         The strip number.
     """
-    return np.uint16((cgem_digi_id & DIGI_CGEM_STRIP_MASK) >> DIGI_CGEM_STRIP_OFFSET)
+    return (cgem_digi_id & DIGI_CGEM_STRIP_MASK) >> DIGI_CGEM_STRIP_OFFSET
 
 
 @nb.vectorize(cache=True)

--- a/src/pybes3/helix.py
+++ b/src/pybes3/helix.py
@@ -539,7 +539,7 @@ def kappa_to_charge(kappa: FloatLike) -> IntLike:
     Returns:
         charge of the helix.
     """
-    return np.int8(1) if kappa > 1e-10 else np.int8(-1) if kappa < -1e-10 else np.int8(0)
+    return 1 if kappa > 1e-10 else -1 if kappa < -1e-10 else 0
 
 
 @nb.vectorize(cache=True)

--- a/src/pybes3/identifier.py
+++ b/src/pybes3/identifier.py
@@ -7,71 +7,71 @@ import numpy as np
 import pybes3.detectors as det
 from pybes3.typing import BoolLike, IntLike
 
-DIGI_MDC_FLAG = np.uint32(0x10)
-DIGI_TOF_FLAG = np.uint32(0x20)
-DIGI_EMC_FLAG = np.uint32(0x30)
-DIGI_MUC_FLAG = np.uint32(0x40)
-DIGI_HLT_FLAG = np.uint32(0x50)
-DIGI_CGEM_FLAG = np.uint32(0x60)
-DIGI_MRPC_FLAG = np.uint32(0x70)
-DIGI_FLAG_OFFSET = np.uint32(24)
-DIGI_FLAG_MASK = np.uint32(0xFF000000)
+DIGI_MDC_FLAG = 0x10
+DIGI_TOF_FLAG = 0x20
+DIGI_EMC_FLAG = 0x30
+DIGI_MUC_FLAG = 0x40
+DIGI_HLT_FLAG = 0x50
+DIGI_CGEM_FLAG = 0x60
+DIGI_MRPC_FLAG = 0x70
+DIGI_FLAG_OFFSET = 24
+DIGI_FLAG_MASK = 0xFF000000
 
 # MDC
-DIGI_MDC_WIRETYPE_OFFSET = np.uint32(15)
-DIGI_MDC_WIRETYPE_MASK = np.uint32(0x00008000)
-DIGI_MDC_LAYER_OFFSET = np.uint32(9)
-DIGI_MDC_LAYER_MASK = np.uint32(0x00007E00)
-DIGI_MDC_WIRE_OFFSET = np.uint32(0)
-DIGI_MDC_WIRE_MASK = np.uint32(0x000001FF)
-DIGI_MDC_STEREO_WIRE = np.uint32(1)
+DIGI_MDC_WIRETYPE_OFFSET = 15
+DIGI_MDC_WIRETYPE_MASK = 0x00008000
+DIGI_MDC_LAYER_OFFSET = 9
+DIGI_MDC_LAYER_MASK = 0x00007E00
+DIGI_MDC_WIRE_OFFSET = 0
+DIGI_MDC_WIRE_MASK = 0x000001FF
+DIGI_MDC_STEREO_WIRE = 1
 
 # TOF
-DIGI_TOF_PART_OFFSET = np.uint32(14)
-DIGI_TOF_PART_MASK = np.uint32(0x0000C000)
-DIGI_TOF_END_OFFSET = np.uint32(0)
-DIGI_TOF_END_MASK = np.uint32(0x00000001)
+DIGI_TOF_PART_OFFSET = 14
+DIGI_TOF_PART_MASK = 0x0000C000
+DIGI_TOF_END_OFFSET = 0
+DIGI_TOF_END_MASK = 0x00000001
 
-DIGI_TOF_SCINT_LAYER_OFFSET = np.uint32(8)
-DIGI_TOF_SCINT_LAYER_MASK = np.uint32(0x00000100)
-DIGI_TOF_SCINT_PHI_OFFSET = np.uint32(1)
-DIGI_TOF_SCINT_PHI_MASK = np.uint32(0x000000FE)
+DIGI_TOF_SCINT_LAYER_OFFSET = 8
+DIGI_TOF_SCINT_LAYER_MASK = 0x00000100
+DIGI_TOF_SCINT_PHI_OFFSET = 1
+DIGI_TOF_SCINT_PHI_MASK = 0x000000FE
 
-DIGI_TOF_MRPC_ENDCAP_OFFSET = np.uint32(11)
-DIGI_TOF_MRPC_ENDCAP_MASK = np.uint32(0x00000800)
-DIGI_TOF_MRPC_MODULE_OFFSET = np.uint32(5)
-DIGI_TOF_MRPC_MODULE_MASK = np.uint32(0x000007E0)
-DIGI_TOF_MRPC_STRIP_OFFSET = np.uint32(1)
-DIGI_TOF_MRPC_STRIP_MASK = np.uint32(0x0000001E)
+DIGI_TOF_MRPC_ENDCAP_OFFSET = 11
+DIGI_TOF_MRPC_ENDCAP_MASK = 0x00000800
+DIGI_TOF_MRPC_MODULE_OFFSET = 5
+DIGI_TOF_MRPC_MODULE_MASK = 0x000007E0
+DIGI_TOF_MRPC_STRIP_OFFSET = 1
+DIGI_TOF_MRPC_STRIP_MASK = 0x0000001E
 
 # EMC
-DIGI_EMC_MODULE_OFFSET = np.uint32(16)
-DIGI_EMC_MODULE_MASK = np.uint32(0x000F0000)
-DIGI_EMC_THETA_OFFSET = np.uint32(8)
-DIGI_EMC_THETA_MASK = np.uint32(0x00003F00)
-DIGI_EMC_PHI_OFFSET = np.uint32(0)
-DIGI_EMC_PHI_MASK = np.uint32(0x000000FF)
+DIGI_EMC_MODULE_OFFSET = 16
+DIGI_EMC_MODULE_MASK = 0x000F0000
+DIGI_EMC_THETA_OFFSET = 8
+DIGI_EMC_THETA_MASK = 0x00003F00
+DIGI_EMC_PHI_OFFSET = 0
+DIGI_EMC_PHI_MASK = 0x000000FF
 
 # MUC
-DIGI_MUC_PART_OFFSET = np.uint32(16)
-DIGI_MUC_PART_MASK = np.uint32(0x000F0000)
-DIGI_MUC_SEGMENT_OFFSET = np.uint32(12)
-DIGI_MUC_SEGMENT_MASK = np.uint32(0x0000F000)
-DIGI_MUC_LAYER_OFFSET = np.uint32(8)
-DIGI_MUC_LAYER_MASK = np.uint32(0x00000F00)
-DIGI_MUC_CHANNEL_OFFSET = np.uint32(0)
-DIGI_MUC_CHANNEL_MASK = np.uint32(0x000000FF)
+DIGI_MUC_PART_OFFSET = 16
+DIGI_MUC_PART_MASK = 0x000F0000
+DIGI_MUC_SEGMENT_OFFSET = 12
+DIGI_MUC_SEGMENT_MASK = 0x0000F000
+DIGI_MUC_LAYER_OFFSET = 8
+DIGI_MUC_LAYER_MASK = 0x00000F00
+DIGI_MUC_CHANNEL_OFFSET = 0
+DIGI_MUC_CHANNEL_MASK = 0x000000FF
 
 # CGEM
-DIGI_CGEM_STRIP_OFFSET = np.uint32(7)
-DIGI_CGEM_STRIP_MASK = np.uint32(0x0007FF80)
-DIGI_CGEM_STRIPTYPE_OFFSET = np.uint32(6)
-DIGI_CGEM_STRIPTYPE_MASK = np.uint32(0x00000040)
-DIGI_CGEM_SHEET_OFFSET = np.uint32(3)
-DIGI_CGEM_SHEET_MASK = np.uint32(0x00000038)
-DIGI_CGEM_LAYER_OFFSET = np.uint32(0)
-DIGI_CGEM_LAYER_MASK = np.uint32(0x00000007)
-DIGI_CGEM_XSTRIP = np.uint32(0)
+DIGI_CGEM_STRIP_OFFSET = 7
+DIGI_CGEM_STRIP_MASK = 0x0007FF80
+DIGI_CGEM_STRIPTYPE_OFFSET = 6
+DIGI_CGEM_STRIPTYPE_MASK = 0x00000040
+DIGI_CGEM_SHEET_OFFSET = 3
+DIGI_CGEM_SHEET_MASK = 0x00000038
+DIGI_CGEM_LAYER_OFFSET = 0
+DIGI_CGEM_LAYER_MASK = 0x00000007
+DIGI_CGEM_XSTRIP = 0
 
 
 def _add_field_if_exist(digi: ak.Array | dict, res: dict, field: str, output: str):
@@ -111,7 +111,7 @@ def mdc_id_to_wire(mdc_id: IntLike) -> IntLike:
     Returns:
         The wire number.
     """
-    return np.uint16((mdc_id & DIGI_MDC_WIRE_MASK) >> DIGI_MDC_WIRE_OFFSET)
+    return (mdc_id & DIGI_MDC_WIRE_MASK) >> DIGI_MDC_WIRE_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -125,7 +125,7 @@ def mdc_id_to_layer(mdc_id: IntLike) -> IntLike:
     Returns:
         The layer number.
     """
-    return np.uint8((mdc_id & DIGI_MDC_LAYER_MASK) >> DIGI_MDC_LAYER_OFFSET)
+    return (mdc_id & DIGI_MDC_LAYER_MASK) >> DIGI_MDC_LAYER_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -291,7 +291,7 @@ def tof_id_to_part(tof_id: IntLike) -> IntLike:
     part = (tof_id & DIGI_TOF_PART_MASK) >> DIGI_TOF_PART_OFFSET
     if part == 3:  # += MRPC endcap number
         part += (tof_id & DIGI_TOF_MRPC_ENDCAP_MASK) >> DIGI_TOF_MRPC_ENDCAP_OFFSET
-    return np.uint8(part)
+    return part
 
 
 @nb.vectorize(cache=True)
@@ -305,7 +305,7 @@ def tof_id_to_end(tof_id: IntLike) -> IntLike:
     Returns:
         The readout end number.
     """
-    return np.uint8((tof_id & DIGI_TOF_END_MASK) >> DIGI_TOF_END_OFFSET)
+    return (tof_id & DIGI_TOF_END_MASK) >> DIGI_TOF_END_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -327,7 +327,7 @@ def _tof_id_to_layer_or_module_1(tof_id: IntLike) -> IntLike:
         res = (tof_id & DIGI_TOF_SCINT_LAYER_MASK) >> DIGI_TOF_SCINT_LAYER_OFFSET
     else:
         res = (tof_id & DIGI_TOF_MRPC_MODULE_MASK) >> DIGI_TOF_MRPC_MODULE_OFFSET
-    return np.uint8(res)
+    return res
 
 
 @nb.vectorize(cache=True)
@@ -348,7 +348,7 @@ def _tof_id_to_layer_or_module_2(tof_id: IntLike, part: IntLike) -> IntLike:
         res = (tof_id & DIGI_TOF_SCINT_LAYER_MASK) >> DIGI_TOF_SCINT_LAYER_OFFSET
     else:
         res = (tof_id & DIGI_TOF_MRPC_MODULE_MASK) >> DIGI_TOF_MRPC_MODULE_OFFSET
-    return np.uint8(res)
+    return res
 
 
 def tof_id_to_layer_or_module(
@@ -392,7 +392,7 @@ def _tof_id_to_phi_or_strip_1(tof_id: IntLike) -> IntLike:
         res = (tof_id & DIGI_TOF_SCINT_PHI_MASK) >> DIGI_TOF_SCINT_PHI_OFFSET
     else:
         res = (tof_id & DIGI_TOF_MRPC_STRIP_MASK) >> DIGI_TOF_MRPC_STRIP_OFFSET
-    return np.uint8(res)
+    return res
 
 
 @nb.vectorize(cache=True)
@@ -413,7 +413,7 @@ def _tof_id_to_phi_or_strip_2(tof_id: IntLike, part: IntLike) -> IntLike:
         res = (tof_id & DIGI_TOF_SCINT_PHI_MASK) >> DIGI_TOF_SCINT_PHI_OFFSET
     else:
         res = (tof_id & DIGI_TOF_MRPC_STRIP_MASK) >> DIGI_TOF_MRPC_STRIP_OFFSET
-    return np.uint8(res)
+    return res
 
 
 def tof_id_to_phi_or_strip(
@@ -615,7 +615,7 @@ def emc_id_to_module(emc_id: IntLike) -> IntLike:
     Returns:
         The module number.
     """
-    return np.uint8((emc_id & DIGI_EMC_MODULE_MASK) >> DIGI_EMC_MODULE_OFFSET)
+    return (emc_id & DIGI_EMC_MODULE_MASK) >> DIGI_EMC_MODULE_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -629,7 +629,7 @@ def emc_id_to_theta(emc_id: IntLike) -> IntLike:
     Returns:
         The theta number.
     """
-    return np.uint8((emc_id & DIGI_EMC_THETA_MASK) >> DIGI_EMC_THETA_OFFSET)
+    return (emc_id & DIGI_EMC_THETA_MASK) >> DIGI_EMC_THETA_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -643,7 +643,7 @@ def emc_id_to_phi(emc_id: IntLike) -> IntLike:
     Returns:
         The phi number.
     """
-    return np.uint8((emc_id & DIGI_EMC_PHI_MASK) >> DIGI_EMC_PHI_OFFSET)
+    return (emc_id & DIGI_EMC_PHI_MASK) >> DIGI_EMC_PHI_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -795,7 +795,7 @@ def muc_id_to_part(muc_id: IntLike) -> IntLike:
     Returns:
         The part number.
     """
-    return np.uint8((muc_id & DIGI_MUC_PART_MASK) >> DIGI_MUC_PART_OFFSET)
+    return (muc_id & DIGI_MUC_PART_MASK) >> DIGI_MUC_PART_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -809,7 +809,7 @@ def muc_id_to_segment(muc_id: IntLike) -> IntLike:
     Returns:
         The segment number.
     """
-    return np.uint8((muc_id & DIGI_MUC_SEGMENT_MASK) >> DIGI_MUC_SEGMENT_OFFSET)
+    return (muc_id & DIGI_MUC_SEGMENT_MASK) >> DIGI_MUC_SEGMENT_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -823,7 +823,7 @@ def muc_id_to_layer(muc_id: IntLike) -> IntLike:
     Returns:
         The layer number.
     """
-    return np.uint8((muc_id & DIGI_MUC_LAYER_MASK) >> DIGI_MUC_LAYER_OFFSET)
+    return (muc_id & DIGI_MUC_LAYER_MASK) >> DIGI_MUC_LAYER_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -837,7 +837,7 @@ def muc_id_to_channel(muc_id: IntLike) -> IntLike:
     Returns:
         The channel number.
     """
-    return np.uint8((muc_id & DIGI_MUC_CHANNEL_MASK) >> DIGI_MUC_CHANNEL_OFFSET)
+    return (muc_id & DIGI_MUC_CHANNEL_MASK) >> DIGI_MUC_CHANNEL_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -958,7 +958,7 @@ def cgem_id_to_layer(cgem_id: IntLike) -> IntLike:
     Returns:
         The layer number.
     """
-    return np.uint8((cgem_id & DIGI_CGEM_LAYER_MASK) >> DIGI_CGEM_LAYER_OFFSET)
+    return (cgem_id & DIGI_CGEM_LAYER_MASK) >> DIGI_CGEM_LAYER_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -972,7 +972,7 @@ def cgem_id_to_sheet(cgem_id: IntLike) -> IntLike:
     Returns:
         The sheet number.
     """
-    return np.uint8((cgem_id & DIGI_CGEM_SHEET_MASK) >> DIGI_CGEM_SHEET_OFFSET)
+    return (cgem_id & DIGI_CGEM_SHEET_MASK) >> DIGI_CGEM_SHEET_OFFSET
 
 
 @nb.vectorize(cache=True)
@@ -986,7 +986,7 @@ def cgem_id_to_strip_type(cgem_id: IntLike) -> IntLike:
     Returns:
         The strip type. 0 for X-strip, 1 for V-strip.
     """
-    return np.uint8((cgem_id & DIGI_CGEM_STRIPTYPE_MASK) >> DIGI_CGEM_STRIPTYPE_OFFSET)
+    return (cgem_id & DIGI_CGEM_STRIPTYPE_MASK) >> DIGI_CGEM_STRIPTYPE_OFFSET
 
 
 @nb.vectorize(cache=True)


### PR DESCRIPTION
This pull request standardizes the use of integer types across the codebase by removing explicit NumPy integer types (e.g., `np.uint8`, `np.uint16`, `np.int8`, `np.uint32`) in favor of native Python integers or `np.int64` where necessary. It also updates array initializations and geometry table loading to use consistent integer types, and improves error handling in `get_emc_gid`. These changes help ensure type consistency, improve code clarity, and may help with cross-platform compatibility.

**Type Standardization and Consistency:**

* Replaced explicit NumPy integer types (e.g., `np.uint8`, `np.uint16`, `np.uint32`, `np.int8`) with native Python integers in all bitmasking and ID extraction functions in `digi_id.py`, as well as in the `kappa_to_charge` function in `helix.py`. [[1]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL20-R84) [[2]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL115-R115) [[3]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL129-R129) [[4]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL313-R313) [[5]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL327-R327) [[6]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL349-R349) [[7]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL370-R370) [[8]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL414-R414) [[9]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL435-R435) [[10]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL577-R577) [[11]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL591-R591) [[12]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL605-R605) [[13]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL764-R764) [[14]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL778-R778) [[15]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL792-R792) [[16]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL806-R806) [[17]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL944-R944) [[18]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL958-R958) [[19]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL972-R972) [[20]](diffhunk://#diff-0b6e07c82dc81bd333e12bcb06bdeb75422ace0959ec9788e0c7140061b5eb8fL986-R986) [[21]](diffhunk://#diff-702b670a9522bbb9b2355b592872e9fa1dd927867423f335ecbf5a70f7a4fbbeL542-R542)

* Updated array initializations in detector modules (`cgem.py`, `tof.py`, `mdc.py`) to use `np.int64` instead of smaller unsigned types, ensuring consistency and avoiding potential overflow issues. [[1]](diffhunk://#diff-b2442c066c22ef8a36ab8a4469b88461fcf0fe99347a6e99d52105820b4dcc3eL26-R29) [[2]](diffhunk://#diff-845d84b2a0947a3b7457d8879391f59bd5fb57fc912e5c9906ec880e4539dbdeL21-R23) [[3]](diffhunk://#diff-b7b2c29aa6b6c87ab17ae44d97cb81b5aed69e8d070c3ef8e80e79cedc668897L17-R37)

**Geometry Table Loading Improvements:**

* When loading geometry tables in `emc.py` and `mdc.py`, now explicitly casts relevant fields to `np.int64` for type consistency. [[1]](diffhunk://#diff-61bf5cf5b6da21a4f64d87bf23adc0c63362bd3e6440fb8f6bcd321bf306c037L32-R34) [[2]](diffhunk://#diff-b7b2c29aa6b6c87ab17ae44d97cb81b5aed69e8d070c3ef8e80e79cedc668897L17-R37)

**Error Handling Improvements:**

* In `get_emc_gid` (`emc.py`), replaced the default return of `np.uint16(65535)` with a `ValueError` for unsupported `part` values, improving error reporting and code robustness.