### PR TITLE
chore: adopt to uproot-custom v2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "scikit_build_core.build"
-requires = ["scikit-build-core", "pybind11==3.0.*", "uproot-custom @ file:///home/mrli/work/my-uproot/uproot-custom/dist/uproot_custom-2.3.2.dev4+g71d0822de.tar.gz"]
+requires = ["scikit-build-core", "pybind11==3.0.*", "uproot-custom==2.4.*"]
 
 [dependency-groups]
 dev = [
@@ -41,7 +41,7 @@ dependencies = [
   "awkward",
   "numba",
   "vector!=1.7.0",  # Vector 1.7.0 is the last version to support Python 3.9, but it has a bug that breaks pybes3, so we need to exclude it.
-  "uproot-custom @ file:///home/mrli/work/my-uproot/uproot-custom/dist/uproot_custom-2.3.2.dev4+g71d0822de.tar.gz"
+  "uproot-custom==2.4.*"
 ]
 description = "Unofficial Python module for BES3"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "scikit_build_core.build"
-requires = ["scikit-build-core", "pybind11==3.0.*", "uproot-custom==2.3.*"]
+requires = ["scikit-build-core", "pybind11==3.0.*", "uproot-custom @ file:///home/mrli/work/my-uproot/uproot-custom/dist/uproot_custom-2.3.2.dev4+g71d0822de.tar.gz"]
 
 [dependency-groups]
 dev = [
@@ -41,7 +41,7 @@ dependencies = [
   "awkward",
   "numba",
   "vector!=1.7.0",  # Vector 1.7.0 is the last version to support Python 3.9, but it has a bug that breaks pybes3, so we need to exclude it.
-  "uproot-custom==2.3.*"
+  "uproot-custom @ file:///home/mrli/work/my-uproot/uproot-custom/dist/uproot_custom-2.3.2.dev4+g71d0822de.tar.gz"
 ]
 description = "Unofficial Python module for BES3"
 dynamic = ["version"]

--- a/src/pybes3/besio/cpp/root_io.hh
+++ b/src/pybes3/besio/cpp/root_io.hh
@@ -23,31 +23,31 @@ class Bes3TObjArrayReader : public IReader {
         , m_element_reader( element_reader )
         , m_offsets( make_shared_vector<uint32_t>( 1, 0 ) ) {}
 
-    void read( BinaryBuffer& bparser ) override {
+    void read( BinaryStream& stream ) override {
         debug_printf( "Bes3TObjArrayReader %s: reading...\n", m_name.c_str() );
-        debug_printf( bparser );
+        debug_printf( stream );
 
-        bparser.skip_fNBytes();
-        bparser.skip_fVersion();
-        bparser.skip_fVersion();
-        bparser.skip( 4 ); // fUniqueID
-        bparser.skip( 4 ); // fBits
+        stream.skip_fNBytes();
+        stream.skip_fVersion();
+        stream.skip_fVersion();
+        stream.skip( 4 ); // fUniqueID
+        stream.skip( 4 ); // fBits
 
-        bparser.skip( 1 ); // fName
-        auto fSize = bparser.read<uint32_t>();
-        bparser.skip( 4 ); // fLowerBound
+        stream.skip( 1 ); // fName
+        auto fSize = stream.read<uint32_t>();
+        stream.skip( 4 ); // fLowerBound
 
         m_offsets->push_back( m_offsets->back() + fSize );
         for ( uint32_t i = 0; i < fSize; i++ )
         {
 
-            bparser.skip_obj_header();
+            stream.skip_obj_header();
 
             debug_printf( "Bes3TObjArrayReader %s: skipped obj header of %d element\n",
                           m_name.c_str(), i );
-            debug_printf( bparser );
+            debug_printf( stream );
 
-            m_element_reader->read( bparser );
+            m_element_reader->read( stream );
         }
     }
 
@@ -91,10 +91,10 @@ class Bes3SymMatrixArrayReader : public IReader {
         return i < j ? j * ( j + 1 ) / 2 + i : i * ( i + 1 ) / 2 + j;
     }
 
-    void read( BinaryBuffer& bparser ) override {
+    void read( BinaryStream& stream ) override {
         // temporary flat array to hold the data
         std::vector<T> flat_array( m_flat_size );
-        for ( int i = 0; i < m_flat_size; i++ ) flat_array[i] = bparser.read<T>();
+        for ( int i = 0; i < m_flat_size; i++ ) flat_array[i] = stream.read<T>();
 
         // fill the m_data with the symmetric matrix data
         for ( int i = 0; i < m_full_dim; i++ )
@@ -148,27 +148,27 @@ class Bes3CgemClusterColReader : public IReader {
         , m_clusterflag( make_shared_vector<int32_t>() )
         , m_stripid( make_shared_vector<int32_t>() ) {}
 
-    void read( BinaryBuffer& bparser ) override {
-        bparser.skip_obj_header();
+    void read( BinaryStream& stream ) override {
+        stream.skip_obj_header();
 
         // TObjArray
-        bparser.skip_fNBytes();
-        bparser.skip_fVersion();
-        bparser.skip_fVersion();
-        bparser.skip( 4 ); // fUniqueID
-        bparser.skip( 4 ); // fBits
-        bparser.skip( 1 ); // fName
-        auto fSize = bparser.read<uint32_t>();
-        bparser.skip( 4 ); // fLowerBound
+        stream.skip_fNBytes();
+        stream.skip_fVersion();
+        stream.skip_fVersion();
+        stream.skip( 4 ); // fUniqueID
+        stream.skip( 4 ); // fBits
+        stream.skip( 1 ); // fName
+        auto fSize = stream.read<uint32_t>();
+        stream.skip( 4 ); // fLowerBound
 
         m_offsets->push_back( m_offsets->back() + fSize );
 
         for ( uint32_t i = 0; i < fSize; i++ )
         {
-            bparser.skip_obj_header();
+            stream.skip_obj_header();
 
-            auto fNBytes = bparser.read_fNBytes();
-            bparser.skip_fVersion();
+            auto fNBytes = stream.read_fNBytes();
+            stream.skip_fVersion();
 
             // Determine class version
             if ( m_version == -1 )
@@ -184,25 +184,25 @@ class Bes3CgemClusterColReader : public IReader {
             }
 
             // TObject
-            bparser.skip_TObject();
+            stream.skip_TObject();
 
             // TRecCgemCluster
-            m_clusterid->push_back( bparser.read<int32_t>() );
-            m_trkid->push_back( bparser.read<int32_t>() );
-            m_layerid->push_back( bparser.read<int32_t>() );
-            m_sheetid->push_back( bparser.read<int32_t>() );
-            m_flag->push_back( bparser.read<int32_t>() );
-            m_energydeposit->push_back( bparser.read<double>() );
-            m_recphi->push_back( bparser.read<double>() );
-            if ( m_version == 0 ) m_recpositiony->push_back( bparser.read<double>() );
-            m_recv->push_back( bparser.read<double>() );
-            m_recZ->push_back( bparser.read<double>() );
+            m_clusterid->push_back( stream.read<int32_t>() );
+            m_trkid->push_back( stream.read<int32_t>() );
+            m_layerid->push_back( stream.read<int32_t>() );
+            m_sheetid->push_back( stream.read<int32_t>() );
+            m_flag->push_back( stream.read<int32_t>() );
+            m_energydeposit->push_back( stream.read<double>() );
+            m_recphi->push_back( stream.read<double>() );
+            if ( m_version == 0 ) m_recpositiony->push_back( stream.read<double>() );
+            m_recv->push_back( stream.read<double>() );
+            m_recZ->push_back( stream.read<double>() );
 
             // m_clusterflag is int[2]
-            for ( int i = 0; i < 2; i++ ) m_clusterflag->push_back( bparser.read<int32_t>() );
+            for ( int i = 0; i < 2; i++ ) m_clusterflag->push_back( stream.read<int32_t>() );
 
             // m_stripid is int[2][2]
-            for ( int i = 0; i < 4; i++ ) m_stripid->push_back( bparser.read<int32_t>() );
+            for ( int i = 0; i < 4; i++ ) m_stripid->push_back( stream.read<int32_t>() );
         }
     }
 

--- a/src/pybes3/besio/root_io.py
+++ b/src/pybes3/besio/root_io.py
@@ -252,9 +252,7 @@ class Bes3PyCgemClusterColReader(uproot_custom.readers.python.IReader):
 
             if self.version == -1:
                 if fNBytes not in (96, 88):
-                    raise ValueError(
-                        f"Unknown TCgemCluster version with FNBytes = {fNBytes}"
-                    )
+                    raise ValueError(f"Unknown TCgemCluster version with FNBytes = {fNBytes}")
 
                 self.version = 0 if fNBytes == 96 else 1
 

--- a/src/pybes3/besio/root_io.py
+++ b/src/pybes3/besio/root_io.py
@@ -8,7 +8,9 @@ import uproot
 import uproot.behaviors.TBranch
 import uproot.extras
 import uproot.interpretation
-import uproot_custom.cpp
+import uproot_custom.readers.cpp
+import uproot_custom.readers.python
+import array
 from uproot_custom import (
     AnyClassFactory,
     AsCustom,
@@ -70,6 +72,34 @@ bes3_branch2types = {
 }
 
 
+class Bes3PyTObjArrayReader(uproot_custom.readers.python.IReader):
+    def __init__(self, name, element_reader: uproot_custom.readers.python.IReader):
+        super().__init__(name)
+        self.element_reader = element_reader
+        self.offsets = array.array("I", [0])
+
+    def read(self, stream):
+        stream.skip_fNBytes()
+        stream.skip_fVersion()
+        stream.skip_fVersion()
+        stream.skip(4)
+        stream.skip(4)
+
+        stream.skip(1)
+        fSize = stream.read_uint32()
+        stream.skip(4)
+
+        self.offsets.append(self.offsets[-1] + fSize)
+
+        for _ in range(fSize):
+            stream.skip_obj_header()
+            self.element_reader.read(stream)
+
+    def data(self):
+        element_data = self.element_reader.data()
+        return np.asarray(self.offsets), element_data
+
+
 class Bes3TObjArrayFactory(Factory):
     @classmethod
     def priority(cls):
@@ -124,6 +154,10 @@ class Bes3TObjArrayFactory(Factory):
         element_reader = self.element_factory.build_cpp_reader()
         return bcpp.Bes3TObjArrayReader(self.name, element_reader)
 
+    def build_python_reader(self):
+        element_reader = self.element_factory.build_python_reader()
+        return Bes3PyTObjArrayReader(self.name, element_reader)
+
     def make_awkward_content(self, raw_data):
         offsets, element_raw_data = raw_data
         element_content = self.element_factory.make_awkward_content(element_raw_data)
@@ -172,7 +206,103 @@ class Bes3BaseObjectFactory(GroupFactory):
         sub_readers = [s.build_cpp_reader() for s in self.sub_factories]
         # In TObjArray, base class always contains fNBytes+fVersion header,
         # so use `AnyClassReader` instead of `GroupReader` to read it.
-        return uproot_custom.cpp.AnyClassReader(self.name, sub_readers)
+        return uproot_custom.readers.cpp.AnyClassReader(self.name, sub_readers)
+
+    def build_python_reader(self):
+        sub_readers = [s.build_python_reader() for s in self.sub_factories]
+        return uproot_custom.readers.python.AnyClassReader(self.name, sub_readers)
+
+
+class Bes3PyCgemClusterColReader(uproot_custom.readers.python.IReader):
+    def __init__(self, name):
+        super().__init__(name)
+
+        self.version = -1  # -1: unknown, 0: with recpositiony, 1: without recpositiony
+
+        self.offsets = array.array("I", [0])
+        self.clusterid = array.array("i")
+        self.trkid = array.array("i")
+        self.layerid = array.array("i")
+        self.sheetid = array.array("i")
+        self.flag = array.array("i")
+        self.energydeposit = array.array("d")
+        self.recphi = array.array("d")
+        self.recpositiony = array.array("d")
+        self.recv = array.array("d")
+        self.recZ = array.array("d")
+        self.clusterflag = array.array("i")
+        self.stripid = array.array("i")
+
+    def read(self, stream):
+        stream.skip_obj_header()
+
+        # TObjArray
+        stream.skip_fNBytes()
+        stream.skip(13)  # fVersion(2) + fVersion(2) + fUniqueID(4) + fBits(4) + fName(1)
+        fSize = stream.read_uint32()
+        stream.skip(4)  # fLowerBound
+
+        self.offsets.append(self.offsets[-1] + fSize)
+
+        for _ in range(fSize):
+            stream.skip_obj_header()
+
+            fNBytes = stream.read_fNBytes()
+            stream.skip_fVersion()
+
+            if self.version == -1:
+                assert fNBytes in (
+                    96,
+                    88,
+                ), f"Unknown TCgemCluster version with FNBytes = {fNBytes}"
+
+                self.version = 0 if fNBytes == 96 else 1
+
+            stream.skip_TObject()
+
+            self.clusterid.append(stream.read_int32())
+            self.trkid.append(stream.read_int32())
+            self.layerid.append(stream.read_int32())
+            self.sheetid.append(stream.read_int32())
+            self.flag.append(stream.read_int32())
+            self.energydeposit.append(stream.read_double())
+            self.recphi.append(stream.read_double())
+
+            if self.version == 0:
+                self.recpositiony.append(stream.read_double())
+
+            self.recv.append(stream.read_double())
+            self.recZ.append(stream.read_double())
+
+            # m_clusterflag is int[2]
+            for _ in range(2):
+                self.clusterflag.append(stream.read_int32())
+
+            # m_stripid is int[2][2]
+            for _ in range(4):
+                self.stripid.append(stream.read_int32())
+
+    def data(self):
+        result = {}
+
+        result["offsets"] = np.asarray(self.offsets)
+        result["m_clusterID"] = np.asarray(self.clusterid)
+        result["m_trkID"] = np.asarray(self.trkid)
+        result["m_layerID"] = np.asarray(self.layerid)
+        result["m_sheetID"] = np.asarray(self.sheetid)
+        result["m_flag"] = np.asarray(self.flag)
+        result["m_energyDeposit"] = np.asarray(self.energydeposit)
+        result["m_recPhi"] = np.asarray(self.recphi)
+
+        if self.version == 0:
+            result["m_recPositionY"] = np.asarray(self.recpositiony)
+
+        result["m_recV"] = np.asarray(self.recv)
+        result["m_recZ"] = np.asarray(self.recZ)
+        result["m_clusterFlag"] = np.asarray(self.clusterflag)
+        result["m_stripID"] = np.asarray(self.stripid)
+
+        return result
 
 
 class Bes3CgemClusterColFactory(Factory):
@@ -201,6 +331,9 @@ class Bes3CgemClusterColFactory(Factory):
     def build_cpp_reader(self):
         return bcpp.Bes3CgemClusterColReader(self.name)
 
+    def build_python_reader(self):
+        return Bes3PyCgemClusterColReader(self.name)
+
     def make_awkward_content(self, raw_data: dict):
         offsets = raw_data.pop("offsets")
 
@@ -226,6 +359,40 @@ class Bes3CgemClusterColFactory(Factory):
         raise NotImplementedError(
             "make_awkward_form is not implemented for Bes3CgemClusterColFactory"
         )
+
+
+class Bes3PySymMatrixArrayReader(uproot_custom.readers.python.IReader):
+    def __init__(self, name: str, flat_size: int, full_dim: int):
+        super().__init__(name)
+
+        self.flat_size = flat_size
+        self.full_dim = full_dim
+        self._data = array.array("d")
+
+        self._sym_idx = np.empty((full_dim, full_dim), dtype=np.int64)
+        for i in range(full_dim):
+            for j in range(full_dim):
+                idx = self.get_symmetric_matrix_index(i, j)
+                if idx >= flat_size:
+                    raise ValueError(
+                        f"Invalid flat size: {flat_size}, full dim: {full_dim}, "
+                        f"i: {i}, j: {j}, idx: {idx}"
+                    )
+                self._sym_idx[i, j] = idx
+
+    @staticmethod
+    def get_symmetric_matrix_index(i: int, j: int) -> int:
+        return j * (j + 1) // 2 + i if i < j else i * (i + 1) // 2 + j
+
+    def read(self, stream):
+        flat_array = np.empty(self.flat_size, dtype=np.float64)
+        for i in range(self.flat_size):
+            flat_array[i] = stream.read_double()
+
+        self._data.extend(flat_array[self._sym_idx].ravel())
+
+    def data(self):
+        return np.asarray(self._data)
 
 
 class Bes3SymMatrixArrayFactory(Factory):
@@ -294,6 +461,9 @@ class Bes3SymMatrixArrayFactory(Factory):
 
     def build_cpp_reader(self):
         return bcpp.Bes3SymMatrixArrayReader(self.name, self.flat_size, self.full_dim)
+
+    def build_python_reader(self):
+        return Bes3PySymMatrixArrayReader(self.name, self.flat_size, self.full_dim)
 
     def make_awkward_content(self, raw_data: np.ndarray):
         return awkward.contents.NumpyArray(raw_data.reshape(-1, self.full_dim, self.full_dim))

--- a/src/pybes3/besio/root_io.py
+++ b/src/pybes3/besio/root_io.py
@@ -251,10 +251,10 @@ class Bes3PyCgemClusterColReader(uproot_custom.readers.python.IReader):
             stream.skip_fVersion()
 
             if self.version == -1:
-                assert fNBytes in (
-                    96,
-                    88,
-                ), f"Unknown TCgemCluster version with FNBytes = {fNBytes}"
+                if fNBytes not in (96, 88):
+                    raise ValueError(
+                        f"Unknown TCgemCluster version with FNBytes = {fNBytes}"
+                    )
 
                 self.version = 0 if fNBytes == 96 else 1
 


### PR DESCRIPTION
This pull request introduces Python implementations of several C++ readers for custom ROOT data structures, enabling pure Python reading of `TObjArray`, `CgemClusterCol`, and symmetric matrix arrays. It also refactors the codebase to use the new Python readers and updates dependency management to use a local version of `uproot-custom`.

### Python Reader Implementations

* Added `Bes3PyTObjArrayReader`, `Bes3PyCgemClusterColReader`, and `Bes3PySymMatrixArrayReader` classes in `root_io.py`, providing Python equivalents to their C++ counterparts for in-memory parsing of ROOT data structures. [[1]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87R75-R102) [[2]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87L175-R305) [[3]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87R364-R397)
* Updated factory classes (`Bes3TObjArrayFactory`, `Bes3CgemClusterColFactory`, `Bes3SymMatrixArrayFactory`) to include `build_python_reader` methods, returning the new Python reader implementations. [[1]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87R157-R160) [[2]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87R334-R336) [[3]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87R465-R467)

### Refactoring for Reader Abstraction

* Refactored C++ reader method signatures in `root_io.hh` to use `BinaryStream` instead of `BinaryBuffer`, aligning with the new Python interface and simplifying cross-language support. [[1]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L26-R50) [[2]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L94-R97) [[3]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L151-R171) [[4]](diffhunk://#diff-ec3888756dbcdd61bfd0bbe577499d542d1b18dfd51fb17a42b7021f848a1359L187-R205)
* Updated imports and references in `root_io.py` to use the new module structure for Python and C++ readers (e.g., `uproot_custom.readers.cpp`, `uproot_custom.readers.python`). [[1]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87L11-R13) [[2]](diffhunk://#diff-1747208a03cfe62068c0ca36b645b0d5b938e11dd8e8751cb40da00ad33d3d87L175-R305)

### Dependency Management

* Modified `pyproject.toml` to use a local file path for the `uproot-custom` dependency, ensuring the correct development version is used during builds and installs. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L44-R44)