### PR TITLE
perf: explicitly specify return type of vectorized functions to save memory usage

### DIFF
--- a/src/pybes3/detectors/cgem.py
+++ b/src/pybes3/detectors/cgem.py
@@ -23,10 +23,10 @@ N_VSTRIPS.setflags(write=False)
 
 
 def _init():
-    _layer = np.empty(N_STRIPS, dtype=np.int64)
-    _sheet = np.empty(N_STRIPS, dtype=np.int64)
-    _strip_type = np.empty(N_STRIPS, dtype=np.int64)
-    _strip = np.empty(N_STRIPS, dtype=np.int64)
+    _layer = np.empty(N_STRIPS, dtype=np.int16)
+    _sheet = np.empty(N_STRIPS, dtype=np.int16)
+    _strip_type = np.empty(N_STRIPS, dtype=np.int16)
+    _strip = np.empty(N_STRIPS, dtype=np.int32)
 
     gid = 0
     for layer in range(3):
@@ -39,7 +39,7 @@ def _init():
             for strip in range(n_xstrips):
                 _layer[gid] = layer
                 _sheet[gid] = sheet
-                _strip_type[gid] = 0
+                _strip_type[gid] = X_STRIP_TYPE
                 _strip[gid] = strip
                 gid += 1
 
@@ -47,7 +47,7 @@ def _init():
             for strip in range(n_vstrips):
                 _layer[gid] = layer
                 _sheet[gid] = sheet
-                _strip_type[gid] = 1
+                _strip_type[gid] = V_STRIP_TYPE
                 _strip[gid] = strip
                 gid += 1
 
@@ -82,7 +82,7 @@ def get_cgem_gid(
     gid += sheet * (N_XSTRIPS[layer] + N_VSTRIPS[layer])
     gid += strip_type * N_XSTRIPS[layer]
     gid += strip
-    return gid
+    return np.int32(gid)
 
 
 @nb.vectorize(cache=True)

--- a/src/pybes3/detectors/cgem.py
+++ b/src/pybes3/detectors/cgem.py
@@ -8,10 +8,10 @@ import numpy as np
 
 from pybes3.typing import BoolLike, IntLike
 
-N_LAYER = 3
-N_STRIPS = 9897
-X_STRIP_TYPE = 0
-V_STRIP_TYPE = 1
+N_LAYER = np.int8(3)
+N_STRIPS = np.int32(9897)
+X_STRIP_TYPE = np.int8(0)
+V_STRIP_TYPE = np.int8(1)
 
 N_SHEETS = np.array([1, 2, 2])
 N_XSTRIPS = np.array([856, 630, 832])

--- a/src/pybes3/detectors/emc.py
+++ b/src/pybes3/detectors/emc.py
@@ -29,9 +29,9 @@ BARREL_L = 28.0
 with np.load(EMC_GEOM) as f:
     _emc_geom = dict(f)
 
-_part = _emc_geom["part"].astype(np.int64)
-_theta = _emc_geom["theta"].astype(np.int64)
-_phi = _emc_geom["phi"].astype(np.int64)
+_part = _emc_geom["part"].astype(np.int16)
+_theta = _emc_geom["theta"].astype(np.int32)
+_phi = _emc_geom["phi"].astype(np.int32)
 _points_x = _emc_geom["points_x"]
 _points_y = _emc_geom["points_y"]
 _points_z = _emc_geom["points_z"]
@@ -140,32 +140,32 @@ def get_emc_gid(part: IntLike, theta: IntLike, phi: IntLike) -> IntLike:
     if part == 0:
         res = 0
         if theta == 0 or theta == 1:
-            return theta * ENDCAP_PHI_01 + phi
+            return np.int32(theta * ENDCAP_PHI_01 + phi)
 
         res += 2 * ENDCAP_PHI_01
         if theta == 2 or theta == 3:
-            return res + (theta - 2) * ENDCAP_PHI_23 + phi
+            return np.int32(res + (theta - 2) * ENDCAP_PHI_23 + phi)
 
         res += 2 * ENDCAP_PHI_23
         if theta == 4 or theta == 5:
-            return res + (theta - 4) * ENDCAP_PHI_45 + phi
+            return np.int32(res + (theta - 4) * ENDCAP_PHI_45 + phi)
 
     if part == 1:
-        return ENDCAP_CRYSTALS + theta * BARREL_PHI + phi
+        return np.int32(ENDCAP_CRYSTALS + theta * BARREL_PHI + phi)
 
     if part == 2:
         res = ENDCAP_CRYSTALS + BARREL_CRYSTALS
 
         if theta == 4 or theta == 5:
-            return res + (5 - theta) * ENDCAP_PHI_45 + phi
+            return np.int32(res + (5 - theta) * ENDCAP_PHI_45 + phi)
 
         res += 2 * ENDCAP_PHI_45
         if theta == 2 or theta == 3:
-            return res + (3 - theta) * ENDCAP_PHI_23 + phi
+            return np.int32(res + (3 - theta) * ENDCAP_PHI_23 + phi)
 
         res += 2 * ENDCAP_PHI_23
         if theta == 0 or theta == 1:
-            return res + (1 - theta) * ENDCAP_PHI_01 + phi
+            return np.int32(res + (1 - theta) * ENDCAP_PHI_01 + phi)
 
     raise ValueError(f"Unsupported part: {part}")
 

--- a/src/pybes3/detectors/emc.py
+++ b/src/pybes3/detectors/emc.py
@@ -29,9 +29,13 @@ BARREL_L = 28.0
 with np.load(EMC_GEOM) as f:
     _emc_geom = dict(f)
 
-_part = _emc_geom["part"].astype(np.int16)
-_theta = _emc_geom["theta"].astype(np.int32)
-_phi = _emc_geom["phi"].astype(np.int32)
+_emc_geom["part"] = _emc_geom["part"].astype(np.int16)
+_emc_geom["theta"] = _emc_geom["theta"].astype(np.int32)
+_emc_geom["phi"] = _emc_geom["phi"].astype(np.int32)
+
+_part = _emc_geom["part"]
+_theta = _emc_geom["theta"]
+_phi = _emc_geom["phi"]
 _points_x = _emc_geom["points_x"]
 _points_y = _emc_geom["points_y"]
 _points_z = _emc_geom["points_z"]
@@ -63,6 +67,9 @@ def get_emc_geom_table(library: Literal["np", "ak", "pd"] = "np"):
 
     for k in [
         "gid",
+        "part",
+        "theta",
+        "phi",
         "center_x",
         "center_y",
         "center_z",

--- a/src/pybes3/detectors/mdc.py
+++ b/src/pybes3/detectors/mdc.py
@@ -14,10 +14,15 @@ N_WIRES = 6796
 with np.load(MDC_GEOM) as f:
     _mdc_geom_table = dict(f)
 
-_superlayer = _mdc_geom_table["superlayer"].astype(np.int16)
-_layer = _mdc_geom_table["layer"].astype(np.int16)
-_wire = _mdc_geom_table["wire"].astype(np.int32)
-_stereo = _mdc_geom_table["stereo"].astype(np.int8)
+_mdc_geom_table["superlayer"] = _mdc_geom_table["superlayer"].astype(np.int16)
+_mdc_geom_table["layer"] = _mdc_geom_table["layer"].astype(np.int16)
+_mdc_geom_table["wire"] = _mdc_geom_table["wire"].astype(np.int32)
+_mdc_geom_table["stereo"] = _mdc_geom_table["stereo"].astype(np.int8)
+
+_superlayer = _mdc_geom_table["superlayer"]
+_layer = _mdc_geom_table["layer"]
+_wire = _mdc_geom_table["wire"]
+_stereo = _mdc_geom_table["stereo"]
 _is_stereo = _mdc_geom_table["is_stereo"]
 _east_x = _mdc_geom_table["east_x"]
 _east_y = _mdc_geom_table["east_y"]

--- a/src/pybes3/detectors/mdc.py
+++ b/src/pybes3/detectors/mdc.py
@@ -14,10 +14,10 @@ N_WIRES = 6796
 with np.load(MDC_GEOM) as f:
     _mdc_geom_table = dict(f)
 
-_superlayer = _mdc_geom_table["superlayer"].astype(np.int64)
-_layer = _mdc_geom_table["layer"].astype(np.int64)
-_wire = _mdc_geom_table["wire"].astype(np.int64)
-_stereo = _mdc_geom_table["stereo"].astype(np.int64)
+_superlayer = _mdc_geom_table["superlayer"].astype(np.int16)
+_layer = _mdc_geom_table["layer"].astype(np.int16)
+_wire = _mdc_geom_table["wire"].astype(np.int32)
+_stereo = _mdc_geom_table["stereo"].astype(np.int8)
 _is_stereo = _mdc_geom_table["is_stereo"]
 _east_x = _mdc_geom_table["east_x"]
 _east_y = _mdc_geom_table["east_y"]
@@ -26,7 +26,7 @@ _west_x = _mdc_geom_table["west_x"]
 _west_y = _mdc_geom_table["west_y"]
 _west_z = _mdc_geom_table["west_z"]
 
-_layer_start_gid = np.zeros(44, dtype=np.int64)
+_layer_start_gid = np.zeros(44, dtype=np.int32)
 _layer_start_gid[1:] = np.cumsum(np.bincount(_layer, minlength=43))
 
 _dx_dz = (_east_x - _west_x) / (_east_z - _west_z)

--- a/src/pybes3/detectors/tof.py
+++ b/src/pybes3/detectors/tof.py
@@ -18,9 +18,9 @@ N_PHI_OR_STRIP.setflags(write=False)
 
 
 def _init():
-    _part = np.empty(N_STRIPS, dtype=np.int64)
-    _layer_or_module = np.empty(N_STRIPS, dtype=np.int64)
-    _phi_or_strip = np.empty(N_STRIPS, dtype=np.int64)
+    _part = np.empty(N_STRIPS, dtype=np.int16)
+    _layer_or_module = np.empty(N_STRIPS, dtype=np.int16)
+    _phi_or_strip = np.empty(N_STRIPS, dtype=np.int32)
 
     gid = 0
     for part in range(5):
@@ -60,7 +60,7 @@ def get_tof_gid(part: IntLike, layer_or_module: IntLike, phi_or_strip: IntLike) 
     gid = (N_LAYER_OR_MODULE[:part] * N_PHI_OR_STRIP[:part]).sum()
     gid += layer_or_module * N_PHI_OR_STRIP[part]
     gid += phi_or_strip
-    return gid
+    return np.int32(gid)
 
 
 @nb.vectorize(cache=True)


### PR DESCRIPTION
This pull request focuses on standardizing and optimizing the data types used for geometry and detector indexing across several detector modules (`cgem.py`, `emc.py`, `mdc.py`, and `tof.py`). The main goal is to reduce memory usage and ensure consistency by using the smallest adequate NumPy integer types for each field and return value. Additionally, all detector GID (global identifier) calculation functions now explicitly return `np.int32` values for consistency.

**Key changes by theme:**

**Data type standardization and optimization:**
* Changed constants and array initializations in `cgem.py`, `emc.py`, `mdc.py`, and `tof.py` to use smaller, more appropriate NumPy integer types (e.g., `np.int8`, `np.int16`, `np.int32`) instead of the default or `np.int64`. This affects variables like `N_LAYER`, `N_STRIPS`, array dtypes in `_init()` functions, and geometry tables. [[1]](diffhunk://#diff-b2442c066c22ef8a36ab8a4469b88461fcf0fe99347a6e99d52105820b4dcc3eL11-R14) [[2]](diffhunk://#diff-b2442c066c22ef8a36ab8a4469b88461fcf0fe99347a6e99d52105820b4dcc3eL26-R29) [[3]](diffhunk://#diff-61bf5cf5b6da21a4f64d87bf23adc0c63362bd3e6440fb8f6bcd321bf306c037L32-R34) [[4]](diffhunk://#diff-b7b2c29aa6b6c87ab17ae44d97cb81b5aed69e8d070c3ef8e80e79cedc668897L17-R20) [[5]](diffhunk://#diff-845d84b2a0947a3b7457d8879391f59bd5fb57fc912e5c9906ec880e4539dbdeL21-R23)

**Consistent GID return types:**
* Updated all detector GID calculation functions (`get_cgem_gid`, `get_emc_gid`, `get_tof_gid`) to explicitly return `np.int32` values, ensuring a consistent and predictable integer type for downstream processing. [[1]](diffhunk://#diff-b2442c066c22ef8a36ab8a4469b88461fcf0fe99347a6e99d52105820b4dcc3eL85-R85) [[2]](diffhunk://#diff-61bf5cf5b6da21a4f64d87bf23adc0c63362bd3e6440fb8f6bcd321bf306c037L143-R168) [[3]](diffhunk://#diff-845d84b2a0947a3b7457d8879391f59bd5fb57fc912e5c9906ec880e4539dbdeL63-R63)

**Code clarity and maintainability:**
* Replaced hardcoded values for strip types in `cgem.py` with the defined constants `X_STRIP_TYPE` and `V_STRIP_TYPE` for improved code clarity and maintainability.

**Array initialization improvements:**
* Updated array initializations for geometry-related fields (e.g., `_layer_start_gid` in `mdc.py`) to use `np.int32` instead of `np.int64`, further reducing memory footprint.

These changes collectively improve the efficiency, consistency, and maintainability of the detector geometry code.