### PR TITLE
chore: add dependency on run-pytest for build-sdist job

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,6 +34,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build-sdist:
+    needs: run-pytest
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve the build process. The main change is to ensure that the source distribution build (`build-sdist`) only runs after tests have successfully completed.

Workflow improvements:

* Added a dependency so that the `build-sdist` job now waits for the `run-pytest` job to finish before starting, ensuring that source distributions are only built if tests pass.