### PR TITLE
fix: add '-Wall -Werror' options and clear all warnings in C++ kernels

### DIFF
--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -7,12 +7,14 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
 
-add_compile_options(-Wall -Werror)
-
 project(${SKBUILD_PROJECT_NAME}
     VERSION ${SKBUILD_PROJECT_VERSION}
     LANGUAGES CXX C
 )
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wall> $<$<COMPILE_LANGUAGE:CXX>:-Werror>)
+endif()
 
 set(PYBIND11_NEWPYTHON ON)
 find_package(pybind11 REQUIRED)

--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
 
+add_compile_options(-Wall -Werror)
+
 project(${SKBUILD_PROJECT_NAME}
     VERSION ${SKBUILD_PROJECT_VERSION}
     LANGUAGES CXX C

--- a/kernels/io/src/raw_io.cc
+++ b/kernels/io/src/raw_io.cc
@@ -226,7 +226,7 @@ uint32_t RawBinaryParser::read_ROB( const uint32_t field_id ) {
     auto rob_total_size  = read();
     auto rob_header_size = read();
     skip(); // rob_format_version
-    skip(); // rob_source_idenfitier
+    skip(); // rob_source_identifier
 
     auto rob_n_status = read();
     skip( rob_n_status );

--- a/kernels/io/src/raw_io.cc
+++ b/kernels/io/src/raw_io.cc
@@ -667,8 +667,6 @@ void RawBinaryParser::read_cgem_buffer() {
                                  to_string( pack_header ) );
         }
 
-        auto status = ( *cursor >> 26 ) & 0x7;
-        // auto n_hits = ( cursor[1] >> 16 ) & 0xFF; // no need to read this
         auto local_l1_timestamp = cursor[1] & 0xFFFF;
 
         // hits
@@ -716,8 +714,6 @@ void RawBinaryParser::read_cgem_buffer() {
                 "Invalid CGEM UDPSeqCounter[1]: expecting 0xA0000000 but get " +
                 to_string( trailer3 & 0xF0000000 ) );
         }
-
-        status |= ( trailer2 >> 22 ) & 0x38;
 
         if ( ( ( trailer2 >> 20 ) & 0x1F ) != gemroc )
         {

--- a/kernels/io/src/raw_io.cc
+++ b/kernels/io/src/raw_io.cc
@@ -150,9 +150,9 @@ uint32_t RawBinaryParser::read_field() {
     auto flag = read();
     if ( flag != RawFlag::SUB_DETECTOR ) { throw runtime_error( "Invalid field flag" ); }
 
-    auto total_size        = read();
-    auto header_size       = read();
-    auto format_version    = read();
+    auto total_size  = read();
+    auto header_size = read();
+    skip(); // format-version
     auto source_identifier = read();
 
     auto field_id = ( source_identifier >> 16 ) & 0xFFFF;
@@ -188,10 +188,10 @@ uint32_t RawBinaryParser::read_ROS( const uint32_t field_id ) {
     auto flag = read();
     if ( flag != RawFlag::ROS ) { throw runtime_error( "Invalid ROS flag" ); }
 
-    auto total_size        = read();
-    auto header_size       = read();
-    auto format_version    = read();
-    auto source_idenfitier = read();
+    auto total_size  = read();
+    auto header_size = read();
+    skip(); // format-version
+    skip(); // source_idenfitier
 
     auto n_status = read();
     skip( n_status );
@@ -223,10 +223,10 @@ uint32_t RawBinaryParser::read_ROB( const uint32_t field_id ) {
     auto flag = read();
     if ( flag != RawFlag::ROB ) { throw runtime_error( "Invalid ROB flag" ); }
 
-    auto rob_total_size        = read();
-    auto rob_header_size       = read();
-    auto rob_format_version    = read();
-    auto rob_source_idenfitier = read();
+    auto rob_total_size  = read();
+    auto rob_header_size = read();
+    skip(); // rob_format_version
+    skip(); // rob_source_idenfitier
 
     auto rob_n_status = read();
     skip( rob_n_status );
@@ -695,7 +695,7 @@ void RawBinaryParser::read_cgem_buffer() {
         }
 
         auto trailer0 = cursor[0];
-        auto trailer1 = cursor[1];
+        // auto trailer1 = cursor[1];
         auto trailer2 = cursor[2];
         auto trailer3 = cursor[3];
         cursor += 4;

--- a/kernels/io/src/raw_io.hh
+++ b/kernels/io/src/raw_io.hh
@@ -18,7 +18,7 @@ namespace py = pybind11;
 using namespace std;
 
 class RawBinaryParser {
-    enum RawFlag : const uint32_t {
+    enum RawFlag : uint32_t {
         FILE_START      = 0x1234AAAA,
         FILE_NAME       = 0x1234AABB,
         RUN_PARAMS      = 0x1234BBBB,
@@ -33,7 +33,7 @@ class RawBinaryParser {
         ROD          = 0xEE1234EE,
     };
 
-    enum FieldID : const uint32_t {
+    enum FieldID : uint32_t {
         MDC     = 0xA1,
         TOF     = 0xA2,
         EMC     = 0xA3,

--- a/kernels/io/src/root_io.hh
+++ b/kernels/io/src/root_io.hh
@@ -87,7 +87,7 @@ class Bes3SymMatrixArrayReader : public IReader {
         }
     }
 
-    const uint32_t get_symmetric_matrix_index( uint32_t i, uint32_t j ) const {
+    uint32_t get_symmetric_matrix_index( uint32_t i, uint32_t j ) const {
         return i < j ? j * ( j + 1 ) / 2 + i : i * ( i + 1 ) / 2 + j;
     }
 

--- a/kernels/io/src/root_io.hh
+++ b/kernels/io/src/root_io.hh
@@ -71,9 +71,9 @@ class Bes3SymMatrixArrayReader : public IReader {
         , m_data( make_shared_vector<T>() )
         , m_flat_size( flat_size )
         , m_full_dim( full_dim ) {
-        for ( auto i = 0; i < full_dim; i++ )
+        for ( uint32_t i = 0; i < full_dim; i++ )
         {
-            for ( auto j = 0; j < full_dim; j++ )
+            for ( uint32_t j = 0; j < full_dim; j++ )
             {
                 auto idx = get_symmetric_matrix_index( i, j );
                 if ( idx >= flat_size )
@@ -87,19 +87,19 @@ class Bes3SymMatrixArrayReader : public IReader {
         }
     }
 
-    const int get_symmetric_matrix_index( int i, int j ) const {
+    const uint32_t get_symmetric_matrix_index( uint32_t i, uint32_t j ) const {
         return i < j ? j * ( j + 1 ) / 2 + i : i * ( i + 1 ) / 2 + j;
     }
 
     void read( BinaryStream& stream ) override {
         // temporary flat array to hold the data
         std::vector<T> flat_array( m_flat_size );
-        for ( int i = 0; i < m_flat_size; i++ ) flat_array[i] = stream.read<T>();
+        for ( uint32_t i = 0; i < m_flat_size; i++ ) flat_array[i] = stream.read<T>();
 
         // fill the m_data with the symmetric matrix data
-        for ( int i = 0; i < m_full_dim; i++ )
+        for ( uint32_t i = 0; i < m_full_dim; i++ )
         {
-            for ( int j = 0; j < m_full_dim; j++ )
+            for ( uint32_t j = 0; j < m_full_dim; j++ )
             {
                 auto idx = get_symmetric_matrix_index( i, j );
                 m_data->push_back( flat_array[idx] );

--- a/kernels/ufuncs/include/mod.hh
+++ b/kernels/ufuncs/include/mod.hh
@@ -1,5 +1,7 @@
 #pragma once
+
 #define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #define NPY_TARGET_VERSION NPY_2_0_API_VERSION
 
 #include <Python.h>

--- a/kernels/ufuncs/include/ufunc.hh
+++ b/kernels/ufuncs/include/ufunc.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #define NPY_TARGET_VERSION NPY_2_0_API_VERSION
 
 #include "numpy/ndarraytypes.h"
@@ -169,7 +170,8 @@ void decl_ufunc( PyObject* d, const char* name, const char* doc = "" ) {
                                         NOUT, PyUFunc_None, name, doc, 0 );
     if ( obj == NULL ) return;
 
-    if ( PyDict_SetItemString( d, name, obj ) < 0 ) {
+    if ( PyDict_SetItemString( d, name, obj ) < 0 )
+    {
         Py_DECREF( obj );
         return;
     }

--- a/kernels/ufuncs/src/detectors/mdc.cc
+++ b/kernels/ufuncs/src/detectors/mdc.cc
@@ -93,7 +93,7 @@ PyObject* _init_mdc_geom( PyObject* self, PyObject* args ) {
     memcpy( _west_y.data(), PyArray_DATA( west_y ), _west_y.size() * sizeof( double ) );
     memcpy( _west_z.data(), PyArray_DATA( west_z ), _west_z.size() * sizeof( double ) );
 
-    for ( int i = 0; i < (int)N_WIRES; i++ )
+    for ( size_t i = 0; i < N_WIRES; i++ )
     {
         _dx_dz[i] = ( _east_x[i] - _west_x[i] ) / ( _east_z[i] - _west_z[i] );
         _dy_dz[i] = ( _east_y[i] - _west_y[i] ) / ( _east_z[i] - _west_z[i] );

--- a/kernels/ufuncs/src/detectors/mdc.cc
+++ b/kernels/ufuncs/src/detectors/mdc.cc
@@ -93,7 +93,7 @@ PyObject* _init_mdc_geom( PyObject* self, PyObject* args ) {
     memcpy( _west_y.data(), PyArray_DATA( west_y ), _west_y.size() * sizeof( double ) );
     memcpy( _west_z.data(), PyArray_DATA( west_z ), _west_z.size() * sizeof( double ) );
 
-    for ( int i = 0; i < N_WIRES; i++ )
+    for ( int i = 0; i < (int)N_WIRES; i++ )
     {
         _dx_dz[i] = ( _east_x[i] - _west_x[i] ) / ( _east_z[i] - _west_z[i] );
         _dy_dz[i] = ( _east_y[i] - _west_y[i] ) / ( _east_z[i] - _west_z[i] );

--- a/kernels/ufuncs/src/identifier.cc
+++ b/kernels/ufuncs/src/identifier.cc
@@ -5,9 +5,7 @@ constexpr uint32_t DIGI_MDC_FLAG    = 0x10;
 constexpr uint32_t DIGI_TOF_FLAG    = 0x20;
 constexpr uint32_t DIGI_EMC_FLAG    = 0x30;
 constexpr uint32_t DIGI_MUC_FLAG    = 0x40;
-constexpr uint32_t DIGI_HLT_FLAG    = 0x50;
 constexpr uint32_t DIGI_CGEM_FLAG   = 0x60;
-constexpr uint32_t DIGI_MRPC_FLAG   = 0x70;
 constexpr uint32_t DIGI_FLAG_OFFSET = 24;
 constexpr uint32_t DIGI_FLAG_MASK   = 0xFF000000;
 


### PR DESCRIPTION
This pull request introduces several improvements focused on code safety, type consistency, and code cleanliness across the kernel modules. The main changes include enforcing stricter compilation warnings, updating loop and function parameter types to use unsigned integers where appropriate, and cleaning up unused variables and redundant reads in binary parsing routines.

**Build and Compilation Improvements:**
- Added `-Wall` and `-Werror` compiler flags in `kernels/CMakeLists.txt` to enable all warnings and treat them as errors, helping to catch potential issues early in development.

**Type Consistency and Safety:**
- Updated loop counters and function parameters from `int` to `uint32_t` or `size_t` in `kernels/io/src/root_io.hh` and `kernels/ufuncs/src/detectors/mdc.cc` to ensure correct handling of array indices and sizes, reducing the risk of signed/unsigned mismatches and potential bugs. [[1]](diffhunk://#diff-84de8a91374985d56061a55448a0091d4b84a9fb29421daf627a93414002eedfL74-R76) [[2]](diffhunk://#diff-84de8a91374985d56061a55448a0091d4b84a9fb29421daf627a93414002eedfL90-R102) [[3]](diffhunk://#diff-3d07577d8ab9f3a8d929cc27d88db94ddeaba603a6cbf74a07f5970c3f96be67L96-R96)

**Binary Parsing and Code Cleanliness:**
- Replaced unnecessary variable assignments with `skip()` calls for unused fields in binary parsing functions (`read_field`, `read_ROS`, `read_ROB`) in `kernels/io/src/raw_io.cc`, making the intent clearer and avoiding unused variable warnings. [[1]](diffhunk://#diff-a778fff4f4e4647969601b655d7825c585b09d57b98c5e3c6585f9914390a53cL155-R155) [[2]](diffhunk://#diff-a778fff4f4e4647969601b655d7825c585b09d57b98c5e3c6585f9914390a53cL193-R194) [[3]](diffhunk://#diff-a778fff4f4e4647969601b655d7825c585b09d57b98c5e3c6585f9914390a53cL228-R229)
- Commented out the unused `trailer1` variable in `read_cgem_buffer` to prevent compiler warnings about unused variables.